### PR TITLE
Add Users support 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pusher/push-notifications-server-swift/compare/1.0.0...HEAD)
 
-## [1.0.0] - 2019-02-06
+## 1.0.0 - 2019-02-06
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased](https://github.com/pusher/push-notifications-server-swift/compare/1.0.0...HEAD)
+
+## [1.0.0] - 2019-02-06
+
+### Added
+
+- Support for "Authenticated Users" feature: `publishToUsers`, `generateToken` and `deleteUser`.
+
+### Changed
+
+- `publish` renamed to `publishToInterests` (`publish` method deprecated).

--- a/Package.swift
+++ b/Package.swift
@@ -12,15 +12,14 @@ let package = Package(
             targets: ["PushNotifications"])
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
+        .package(url: "https://github.com/IBM-Swift/Swift-JWT.git", from: "3.1.1")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "PushNotifications",
-            dependencies: []),
+            dependencies: ["SwiftJWT"]),
         .testTarget(
             name: "PushNotificationsTests",
             dependencies: ["PushNotifications"])

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"]
 })
 
 // Authenticate User
-pushNotifications.authenticateUser("aaa", completion: { result in
+pushNotifications.authenticateUser("Elon M", completion: { result in
     switch result {
     case .value(let jwtTokenString):
         print("\(jwtTokenString)")
@@ -91,7 +91,7 @@ pushNotifications.authenticateUser("aaa", completion: { result in
 })
 
 // Delete User
-pushNotifications.deleteUser("aaa", completion: { result in
+pushNotifications.deleteUser("Elon M", completion: { result in
     switch result {
     case .value:
         print("User deleted 👌")

--- a/README.md
+++ b/README.md
@@ -81,10 +81,10 @@ pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"]
 })
 
 // Authenticate User
-pushNotifications.authenticateUser("Elon M", completion: { result in
+pushNotifications.generateToken("Elon M", completion: { result in
     switch result {
-    case .value(let jwtTokenString):
-        print("\(jwtTokenString)")
+    case .value(let jwtToken):
+        print("\(jwtToken)")
     case .error(let error):
         print("\(error)")
     }

--- a/README.md
+++ b/README.md
@@ -61,64 +61,44 @@ let publishRequest = [
 ]
 
 // Publish To Interests
-do {
-    try pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
-        switch result {
-        case .value(let publishId):
-            print("\(publishId)")
-        case .error(let error):
-            print("\(error)")
-        }
-    })
-}
-catch {
-    print("\(error)")
-}
+pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+    switch result {
+    case .value(let publishId):
+        print("\(publishId)")
+    case .error(let error):
+        print("\(error)")
+    }
+})
 
 // Publish To Users
-do {
-    try pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"], publishRequest, completion: { result in
-        switch result {
-        case .value(let publishId):
-            print("\(publishId)")
-        case .error(let error):
-            print("\(error)")
-        }
-    })
-}
-catch {
-    print("\(error)")
-}
+pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"], publishRequest, completion: { result in
+    switch result {
+    case .value(let publishId):
+        print("\(publishId)")
+    case .error(let error):
+        print("\(error)")
+    }
+})
 
 // Authenticate User
-do {
-    try pushNotifications.authenticateUser("Forrest Gump", completion: { result in
-        switch result {
-        case .value(let jwtTokenString):
-            print("\(jwtTokenString)")
-        case .error(let error):
-            print("\(error)")
-        }
-    })
-}
-catch {
-    print("\(error)")
-}
+pushNotifications.authenticateUser("aaa", completion: { result in
+    switch result {
+    case .value(let jwtTokenString):
+        print("\(jwtTokenString)")
+    case .error(let error):
+        print("\(error)")
+    }
+})
 
 // Delete User
-do {
-    try pushNotifications.deleteUser("Forrest Gump", completion: { result in
-        switch result {
-        case .value:
-            print("User deleted 👌")
-        case .error(let error):
-            print("\(error)")
-        }
-    })
-}
-catch {
-    print("\(error)")
-}
+pushNotifications.deleteUser("aaa", completion: { result in
+    switch result {
+    case .value:
+        print("User deleted 👌")
+    case .error(let error):
+        print("\(error)")
+    }
+})
 ```
 
 ## Communication

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"]
 })
 
 // Authenticate User
-pushNotifications.generateToken("Elon M", completion: { result in
+pushNotifications.generateToken("Elmo", completion: { result in
     switch result {
     case .value(let jwtToken):
         // 'jwtToken' is a Dictionary<String, String>
@@ -93,7 +93,7 @@ pushNotifications.generateToken("Elon M", completion: { result in
 })
 
 // Delete User
-pushNotifications.deleteUser("Elon M", completion: { result in
+pushNotifications.deleteUser("Elmo", completion: { result in
     switch result {
     case .value:
         print("User deleted 👌")

--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"]
 pushNotifications.generateToken("Elon M", completion: { result in
     switch result {
     case .value(let jwtToken):
+        // 'jwtToken' is a Dictionary<String, String>
+        // Example: ["token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWEiLCJleHAiOjE"]
         print("\(jwtToken)")
     case .error(let error):
         print("\(error)")

--- a/README.md
+++ b/README.md
@@ -60,9 +60,64 @@ let publishRequest = [
   ]
 ]
 
-// Call the publish method.
-try? pushNotifications.publish(interests, publishRequest) { publishId in
-  print(publishId)
+// Publish To Interests
+do {
+    try pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+        switch result {
+        case .value(let publishId):
+            print("\(publishId)")
+        case .error(let error):
+            print("\(error)")
+        }
+    })
+}
+catch {
+    print("\(error)")
+}
+
+// Publish To Users
+do {
+    try pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"], publishRequest, completion: { result in
+        switch result {
+        case .value(let publishId):
+            print("\(publishId)")
+        case .error(let error):
+            print("\(error)")
+        }
+    })
+}
+catch {
+    print("\(error)")
+}
+
+// Authenticate User
+do {
+    try pushNotifications.authenticateUser("Forrest Gump", completion: { result in
+        switch result {
+        case .value(let jwtTokenString):
+            print("\(jwtTokenString)")
+        case .error(let error):
+            print("\(error)")
+        }
+    })
+}
+catch {
+    print("\(error)")
+}
+
+// Delete User
+do {
+    try pushNotifications.deleteUser("Forrest Gump", completion: { result in
+        switch result {
+        case .value:
+            print("User deleted 👌")
+        case .error(let error):
+            print("\(error)")
+        }
+    })
+}
+catch {
+    print("\(error)")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ let package = Package(
     name: "YourProjectName",
     dependencies: [
         ...
-        .package(url: "git@github.com:pusher/push-notifications-server-swift.git", .branch("master")),
+        .package(url: "git@github.com:pusher/push-notifications-server-swift.git", from: "1.0.0",
     ],
     targets: [
       .target(name: "YourProjectName", dependencies: ["PushNotifications", ... ])

--- a/Sources/PushNotifications/JWTTokenGenerable.swift
+++ b/Sources/PushNotifications/JWTTokenGenerable.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftJWT
+
+public struct JWTPayload {
+    let sub: String
+    let exp: Date
+    let iss: String
+    let key: String
+}
+
+public protocol JWTTokenGenerable {
+    func jwtTokenString(payload: JWTPayload, completion: @escaping CompletionHandler<Result<String, Error>>)
+}
+
+private struct JWTClaims: Claims {
+    let sub: String
+    let exp: Date
+    let iss: String
+}
+
+public extension JWTTokenGenerable {
+    func jwtTokenString(payload: JWTPayload, completion: @escaping CompletionHandler<Result<String, Error>>) {
+        let key = payload.key.data(using: .utf8)!
+        let jwtEncoder = JWTEncoder(jwtSigner: JWTSigner.hs256(key: key))
+        do {
+            let jwt = JWT(claims: JWTClaims(sub: payload.sub, exp: payload.exp, iss: payload.iss))
+            let jwtTokenString = try jwtEncoder.encodeToString(jwt)
+            completion(.value(jwtTokenString))
+        } catch {
+            completion(.error(error))
+        }
+    }
+}

--- a/Sources/PushNotifications/JWTTokenGenerable.swift
+++ b/Sources/PushNotifications/JWTTokenGenerable.swift
@@ -8,7 +8,7 @@ public struct JWTPayload {
     let key: String
 }
 
-public protocol JWTTokenGenerable {
+protocol JWTTokenGenerable {
     func jwtTokenString(payload: JWTPayload, completion: @escaping CompletionHandler<Result<String, Error>>)
 }
 
@@ -18,7 +18,7 @@ private struct JWTClaims: Claims {
     let iss: String
 }
 
-public extension JWTTokenGenerable {
+extension JWTTokenGenerable {
     func jwtTokenString(payload: JWTPayload, completion: @escaping CompletionHandler<Result<String, Error>>) {
         let key = payload.key.data(using: .utf8)!
         let jwtEncoder = JWTEncoder(jwtSigner: JWTSigner.hs256(key: key))

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -72,17 +72,17 @@ public struct PushNotifications: JWTTokenGenerable {
     - Parameter publishRequest: Dictionary containing the body of the push notification publish request.
     - Parameter completion: The block to execute when the `publish` operation is complete.
     - Throws: An error of type `PushNotificationsError`.
-    - returns: Publish Id.
+    - returns: Publish id.
     Example usage:
 
     ````
     // Pusher Beams Instance Id.
-    let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
+    let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
     // Pusher Beams Secret Key.
-    let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+    let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
     // PushNotifications instance.
     let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-    // Interests array.
+
     let interests = ["pizza", "donuts"]
     // Publish request: APNs, FCM.
     let publishRequest = [
@@ -98,8 +98,8 @@ public struct PushNotifications: JWTTokenGenerable {
             ]
         ]
     ]
-    // Call the publish method.
-    pushNotifications.publish(interests, publishRequest) { publishId in
+
+    try? pushNotifications.publish(interests, publishRequest) { publishId in
         print(publishId)
     }
     ````
@@ -128,19 +128,18 @@ public struct PushNotifications: JWTTokenGenerable {
     Publish the given `publishRequest` to the specified interests.
     - Parameter interests: Array of strings that contains interests.
     - Parameter publishRequest: Dictionary containing the body of the push notification publish request.
-    - Parameter completion: The block to execute when the `publish` operation is complete.
-    - Throws: An error of type `PushNotificationsError`.
-    - returns: A non-empty device Id string if successful; or a non-nil error otherwise.
+    - Parameter completion: The block to execute when the `publishToInterests` operation is complete.
+    - returns: A non-empty device id string if successful; or a non-nil `PushNotificationsError` error otherwise.
     Example usage:
 
     ````
     // Pusher Beams Instance Id.
-    let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
+    let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
     // Pusher Beams Secret Key.
-    let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+    let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
     // PushNotifications instance.
     let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-    // Interests array.
+
     let interests = ["pizza", "donuts"]
     // Publish request: APNs, FCM.
     let publishRequest = [
@@ -156,11 +155,11 @@ public struct PushNotifications: JWTTokenGenerable {
             ]
         ]
     ]
-    // Call the publish method.
+
     pushNotifications.publishToInterests(interests, publishRequest) { result in
         switch result {
-        case .value(let deviceId):
-            print("Device id: \(deviceId)")
+        case .value(let publishId):
+            print("Publish id: \(publishId)")
         case .error(let error):
             print("Error: \(error)")
         }
@@ -219,7 +218,49 @@ public struct PushNotifications: JWTTokenGenerable {
             completion(.error(error))
         }
     }
-    
+
+    /**
+    Publish the given `publishRequest` to the specified users.
+    - Parameter users: Array of strings that contains user ids.
+    - Parameter publishRequest: Dictionary containing the body of the push notification publish request.
+    - Parameter completion: The block to execute when the `publishToUsers` operation is complete.
+    - returns: A non-empty publish id string if successful; or a non-nil `PushNotificationsError` error otherwise.
+    Example usage:
+
+    ````
+    // Pusher Beams Instance Id.
+    let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+    // Pusher Beams Secret Key.
+    let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+    // PushNotifications instance.
+    let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+    let users = ["user1", "user2", "user3"]
+    // Publish request: APNs, FCM.
+    let publishRequest = [
+        "apns": [
+            "aps": [
+                "alert": "Hello"
+            ]
+        ],
+        "fcm": [
+            "notification": [
+                "title": "Hello",
+				"body":  "Hello, world",
+            ]
+        ]
+    ]
+
+    pushNotifications.publishToUsers(users, publishRequest) { result in
+        switch result {
+        case .value(let publishId):
+            print("Publish id: \(publishId)")
+        case .error(let error):
+            print("Error: \(error)")
+        }
+    }
+    ````
+    */
     public func publishToUsers(_ users: [String], _ publishRequest: [String: Any], completion: @escaping CompletionHandler<Result<String, Error>>) {
         if users.count < 1 {
             return completion(.error(PushNotificationsError.error("[PushNotifications] - Must supply at least one user id.")))
@@ -271,6 +312,31 @@ public struct PushNotifications: JWTTokenGenerable {
         }
     }
 
+    /**
+    Creates a signed JWT for a user id.
+    - Parameter userId: Id of a user for which we want to generate the JWT token.
+    - Parameter completion: The block to execute when the `authenticateUser` operation is complete.
+    - returns: A signed JWT if successful, or a non-nil `PushNotificationsError` error otherwise.
+    Example usage:
+
+    ````
+    // Pusher Beams Instance Id.
+    let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+    // Pusher Beams Secret Key.
+    let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+    // PushNotifications instance.
+    let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+    pushNotifications.authenticateUser("Al Pacino", completion: { result in
+        switch result {
+        case .value(let jwtTokenString):
+            print("\(jwtTokenString)")
+        case .error(let error):
+            print("\(error)")
+        }
+    })
+    ````
+    */
     public func authenticateUser(_ userId: String, completion: @escaping CompletionHandler<Result<String, Error>>) {
         if userId.count < 1 {
             return completion(.error(PushNotificationsError.error("User Id cannot be empty")))
@@ -290,7 +356,32 @@ public struct PushNotifications: JWTTokenGenerable {
             }
         }
     }
-    
+
+    /**
+    Contacts the Beams service to remove all the devices of the given user.
+    - Parameter userId: Id of a user for which we want to remove all the devices.
+    - Parameter completion: The block to execute when the `deleteUser` operation is complete.
+    - returns: Void if successful, or a non-nil `PushNotificationsError` error otherwise.
+    Example usage:
+
+    ````
+    // Pusher Beams Instance Id.
+    let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+    // Pusher Beams Secret Key.
+    let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+    // PushNotifications instance.
+    let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+    pushNotifications.deleteUser("Al Pacino", completion: { result in
+        switch result {
+        case .value:
+            print("User deleted 👌")
+        case .error(let error):
+            print("\(error)")
+        }
+    })
+    ````
+    */
     public func deleteUser(_ userId: String, completion: @escaping CompletionHandler<Result<Void, Error>>) {
         if userId.count < 1 {
             return completion(.error(PushNotificationsError.error("[PushNotifications] - User Id cannot be empty.")))

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -246,7 +246,7 @@ public struct PushNotifications: JWTTokenGenerable {
         "fcm": [
             "notification": [
                 "title": "Hello",
-				"body":  "Hello, world",
+                "body":  "Hello, world",
             ]
         ]
     ]

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -101,61 +101,27 @@ public struct PushNotifications {
     */
     @available(*, deprecated, renamed: "publishToInterests", message: "Use `publishToInterests` method.")
     public func publish(_ interests: [String], _ publishRequest: [String: Any], completion: @escaping (_ publishId: String) -> Void) throws {
-        if instanceId.isEmpty {
-            throw PushNotificationsError.instanceIdCannotBeAnEmptyString
-        }
+        do {
+            try publishToInterests(interests, publishRequest) { result in
+                switch result {
+                case .value(let deviceId):
+                    completion(deviceId)
+                case .error(let error):
+                    /**
+                     Communicationg errors by returning an empty string is not ideal.
+                     Better option would be to set the `publishId` as an optional
+                     or to return the proper error which is implemented in `publishToInterests` method.
 
-        if secretKey.isEmpty {
-            throw PushNotificationsError.secretKeyCannotBeAnEmptyString
-        }
-
-        if interests.isEmpty {
-            throw PushNotificationsError.interestsArrayCannotBeEmpty
-        }
-
-        if interests.count > 100 {
-            throw PushNotificationsError.interestsArrayContainsTooManyInterests(maxInterests: 100)
-        }
-
-        if !(interests.filter { $0.count > 164 }).isEmpty {
-            throw PushNotificationsError.interestsArrayContainsAnInvalidInterest(maxCharacters: 164)
-        }
-
-        let sessionConfiguration = URLSessionConfiguration.default
-        let session = URLSession.init(configuration: sessionConfiguration)
-
-        let urlString = "https://\(instanceId).pushnotifications.pusher.com/publish_api/v1/instances/\(instanceId)/publishes"
-        guard let url = URL(string: urlString) else { return }
-
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Accept")
-        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        urlRequest.setValue("Bearer \(secretKey)", forHTTPHeaderField: "Authorization")
-
-        var mutablePublishRequest = publishRequest
-        mutablePublishRequest["interests"] = interests
-
-        urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: mutablePublishRequest)
-        let dataTask = session.dataTask(with: urlRequest) { (data, response, error) in
-            guard
-                let data = data,
-                let httpURLResponse = response as? HTTPURLResponse
-                else {
-                    return // Improve
-            }
-
-            let statusCode = httpURLResponse.statusCode
-            guard statusCode >= 200 && statusCode < 300, error == nil else {
-                return // Improve
-            }
-
-            if let publishResponse = try? JSONDecoder().decode(PublishResponse.self, from: data) {
-                completion(publishResponse.id)
+                     This is a workaround so we don't break the API.
+                     **/
+                    print("[PushNotifications] - Publish request failed.")
+                    completion("")
+                }
             }
         }
-
-        dataTask.resume()
+        catch {
+            throw PushNotificationsError.error("[PushNotifications] - Publish request failed. Error: \(error)")
+        }
     }
 
     /**

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -329,15 +329,15 @@ public struct PushNotifications: JWTTokenGenerable {
 
     pushNotifications.generateToken("Al Pacino", completion: { result in
         switch result {
-        case .value(let jwtTokenString):
-            print("\(jwtTokenString)")
+        case .value(let jwtToken):
+            print("\(jwtToken)")
         case .error(let error):
             print("\(error)")
         }
     })
     ````
     */
-    public func generateToken(_ userId: String, completion: @escaping CompletionHandler<Result<String, Error>>) {
+    public func generateToken(_ userId: String, completion: @escaping CompletionHandler<Result<Dictionary<String, String>, Error>>) {
         if userId.count < 1 {
             return completion(.error(PushNotificationsError.error("User Id cannot be empty")))
         }
@@ -350,7 +350,7 @@ public struct PushNotifications: JWTTokenGenerable {
         jwtTokenString(payload: jwtPayload) { result in
             switch result {
             case .value(let jwtTokenString):
-                completion(.value(jwtTokenString))
+                completion(.value(["token": jwtTokenString]))
             case .error(let error):
                 completion(.error(error))
             }

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -315,7 +315,7 @@ public struct PushNotifications: JWTTokenGenerable {
     /**
     Creates a signed JWT for a user id.
     - Parameter userId: Id of a user for which we want to generate the JWT token.
-    - Parameter completion: The block to execute when the `authenticateUser` operation is complete.
+    - Parameter completion: The block to execute when the `generateToken` operation is complete.
     - returns: A signed JWT if successful, or a non-nil `PushNotificationsError` error otherwise.
     Example usage:
 
@@ -327,7 +327,7 @@ public struct PushNotifications: JWTTokenGenerable {
     // PushNotifications instance.
     let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
 
-    pushNotifications.authenticateUser("Al Pacino", completion: { result in
+    pushNotifications.generateToken("Al Pacino", completion: { result in
         switch result {
         case .value(let jwtTokenString):
             print("\(jwtTokenString)")
@@ -337,7 +337,7 @@ public struct PushNotifications: JWTTokenGenerable {
     })
     ````
     */
-    public func authenticateUser(_ userId: String, completion: @escaping CompletionHandler<Result<String, Error>>) {
+    public func generateToken(_ userId: String, completion: @escaping CompletionHandler<Result<String, Error>>) {
         if userId.count < 1 {
             return completion(.error(PushNotificationsError.error("User Id cannot be empty")))
         }

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -53,6 +53,7 @@ public struct PushNotifications: JWTTokenGenerable {
     private let maxUserIdLength = 164
     private let maxNumUserIdsWhenPublishing = 1000
     private let tokenTTL = Date(timeIntervalSinceNow: 24 * 60 * 60)
+    private let sdkVersion = "1.0.0"
 
     /**
      Creates a new `PushNotifications` instance.
@@ -349,6 +350,7 @@ public struct PushNotifications: JWTTokenGenerable {
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("Bearer \(secretKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("push-notifications-server-swift \(sdkVersion)", forHTTPHeaderField: "X-Pusher-Library")
         request.httpMethod = httpMethod
         request.httpBody = body
         

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -132,7 +132,7 @@ public struct PushNotifications {
 
         let urlString = "https://\(instanceId).pushnotifications.pusher.com/publish_api/v1/instances/\(instanceId)/publishes"
         guard let url = URL(string: urlString) else { 
-            return completion(.error(PushNotificationsError.error("[PushNotifications] - Error while constructing the URL.")))
+            return completion(.error(PushNotificationsError.error("[PushNotifications] - Error while constructing the URL.\nCheck that the URL string is not an empty string or string contains illegal characters.")))
         }
 
         var urlRequest = URLRequest(url: url)
@@ -147,15 +147,15 @@ public struct PushNotifications {
         urlRequest.httpBody = try? JSONSerialization.data(withJSONObject: mutablePublishRequest)
         let dataTask = session.dataTask(with: urlRequest) { (data, response, error) in
             guard let data = data else {
-                return completion(.error(PushNotificationsError.error("[PushNotifications] - `data` is nil.")))
+                return completion(.error(PushNotificationsError.error("[PushNotifications] - Publish request failed. `data` is nil.")))
             }
             guard let httpURLResponse = response as? HTTPURLResponse else {
-                return completion(.error(PushNotificationsError.error("[PushNotifications] - `httpURLResponse` is nil.")))
+                return completion(.error(PushNotificationsError.error("[PushNotifications] - Publish request failed. `httpURLResponse` is nil.")))
             }
 
             let statusCode = httpURLResponse.statusCode
             guard statusCode >= 200 && statusCode < 300, error == nil else {
-                return completion(.error(PushNotificationsError.error("[PushNotifications] - Publish request failed: \(statusCode)")))
+                return completion(.error(PushNotificationsError.error("[PushNotifications] - Publish request failed. HTTP status code: \(statusCode)")))
             }
 
             if let publishResponse = try? JSONDecoder().decode(PublishResponse.self, from: data) {

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -99,7 +99,7 @@ public struct PushNotifications {
     }
     ````
     */
-    @available(*, deprecated, renamed: "publishToInterests", message: "Use `publishToInterests` method.")
+    @available(*, deprecated, renamed: "publishToInterests(_:_:completion:)", message: "Use 'publishToInterests(_:_:completion:)' method.")
     public func publish(_ interests: [String], _ publishRequest: [String: Any], completion: @escaping (_ publishId: String) -> Void) throws {
         do {
             try publishToInterests(interests, publishRequest) { result in
@@ -114,13 +114,13 @@ public struct PushNotifications {
 
                      This is a workaround so we don't break the API.
                      **/
-                    print("[PushNotifications] - Publish request failed.")
+                    print("[PushNotifications] - Publish request failed: \(error)")
                     completion("")
                 }
             }
         }
         catch {
-            throw PushNotificationsError.error("[PushNotifications] - Publish request failed. Error: \(error)")
+            throw PushNotificationsError.error("[PushNotifications] - Publish request failed: \(error)")
         }
     }
 

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -70,7 +70,7 @@ public struct PushNotifications {
 
     - Throws: An error of type `PushNotificationsError`.
 
-    - returns: Publish Id.
+    - returns: A non-empty device Id string if successful; or a non-nil error otherwise.
 
     Example usage:
  
@@ -101,8 +101,13 @@ public struct PushNotifications {
     ]
 
     // Call the publish method.
-    try? pushNotifications.publish(interests, publishRequest) { publishId in 
-        print(publishId)
+    try? pushNotifications.publish(interests, publishRequest) { result in
+        switch result {
+        case .value(let deviceId):
+            print("Device id: \(deviceId)")
+        case .error(let error):
+            print("Error: \(error)")
+        }
     }
     ````
     */

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -158,7 +158,7 @@ final class PushNotificationsTests: XCTestCase {
         waitForExpectations(timeout: 3)
     }
 
-        func testInterestInTheArrayIsTooLong() {
+    func testInterestInTheArrayIsTooLong() {
         let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
         let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -350,6 +350,8 @@ final class PushNotificationsTests: XCTestCase {
         pushNotifications.generateToken("aaa", completion: { result in
             switch result {
             case .value(let jwtToken):
+                // 'jwtToken' is a Dictionary<String, String>
+                // Example: ["token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWEiLCJleHAiOjE"]
                 XCTAssertNotNil(jwtToken)
                 exp.fulfill()
             case .error:

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -349,8 +349,8 @@ final class PushNotificationsTests: XCTestCase {
 
         pushNotifications.generateToken("aaa", completion: { result in
             switch result {
-            case .value(let jwtTokenString):
-                XCTAssertNotNil(jwtTokenString)
+            case .value(let jwtToken):
+                XCTAssertNotNil(jwtToken)
                 exp.fulfill()
             case .error:
                 XCTFail()
@@ -408,12 +408,11 @@ final class PushNotificationsTests: XCTestCase {
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
     
-        let exp = expectation(description: "It should successfully authenticate the user.")
+        let exp = expectation(description: "It should successfully delete the user.")
 
         pushNotifications.deleteUser("aaa", completion: { result in
             switch result {
-            case .value(let jwtTokenString):
-                XCTAssertNotNil(jwtTokenString)
+            case .value:
                 exp.fulfill()
             case .error:
                 XCTFail()

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -188,12 +188,300 @@ final class PushNotificationsTests: XCTestCase {
         waitForExpectations(timeout: 3)
     }
 
+    func testValidPublishToUsers() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+        let publishRequest = [
+            "apns": [
+                "aps": [
+                    "alert": "hi"
+                ]
+            ]
+        ]
+
+        let exp = expectation(description: "It should successfully publish to users.")
+
+        pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"], publishRequest, completion: { result in
+            switch result {
+            case .value(let publishId):
+                XCTAssertNotNil(publishId)
+                exp.fulfill()
+            case .error:
+                XCTFail()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testPublishToUsersRequiresAtLeastOneUser() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+        let publishRequest = [
+            "apns": [
+                "aps": [
+                    "alert": "hi"
+                ]
+            ]
+        ]
+
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToUsers([], publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testPublishToUsersUserShouldNotBeAnEmptyString() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+        let publishRequest = [
+            "apns": [
+                "aps": [
+                    "alert": "hi"
+                ]
+            ]
+        ]
+
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToUsers([""], publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testPublishToUsersUsernameShouldBeLessThan165Characters() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+        let publishRequest = [
+            "apns": [
+                "aps": [
+                    "alert": "hi"
+                ]
+            ]
+        ]
+
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToUsers(["askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniownvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoin"], publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testPublishToMoreThan1000UsersShouldFail() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+
+        let publishRequest = [
+            "apns": [
+                "aps": [
+                    "alert": "hi"
+                ]
+            ]
+        ]
+        
+        var users: [String] = []
+
+        for _ in 0...1000 {
+            users.append("a")
+        }
+
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToUsers(users, publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testItShouldAuthenticateTheUserSuccessfully() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+    
+        let exp = expectation(description: "It should successfully authenticate the user.")
+
+        pushNotifications.authenticateUser("aaa", completion: { result in
+            switch result {
+            case .value(let jwtTokenString):
+                XCTAssertNotNil(jwtTokenString)
+                exp.fulfill()
+            case .error:
+                XCTFail()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testItShouldFailToAuthenticateUserWithEmptyId() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+    
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.authenticateUser("", completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testItShouldFailToAuthenticateUserWithIdThatIsTooLong() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+    
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.authenticateUser("askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniownvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoin", completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testItShouldDeleteTheUserSuccessfully() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+    
+        let exp = expectation(description: "It should successfully authenticate the user.")
+
+        pushNotifications.deleteUser("aaa", completion: { result in
+            switch result {
+            case .value(let jwtTokenString):
+                XCTAssertNotNil(jwtTokenString)
+                exp.fulfill()
+            case .error:
+                XCTFail()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testItShouldFailToDeleteUserWithEmptyId() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+    
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.deleteUser("", completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testItShouldFailToDeleteUserWithIdThatIsTooLong() {
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+    
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.deleteUser("askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniownvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoin", completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
+    }
+
     static var allTests = [
         ("testValidInstance", testValidInstance),
         ("testInstanceIdShouldNotBeEmptyString", testInstanceIdShouldNotBeEmptyString),
         ("testSecretKeyShouldNotBeEmptyString", testSecretKeyShouldNotBeEmptyString),
         ("testInterestsArrayShouldNotBeEmpty", testInterestsArrayShouldNotBeEmpty),
         ("testInterestsArrayShouldContainMaximumOf100Interests", testInterestsArrayShouldContainMaximumOf100Interests),
-        ("testInterestInTheArrayIsTooLong", testInterestInTheArrayIsTooLong)
+        ("testInterestInTheArrayIsTooLong", testInterestInTheArrayIsTooLong),
+        ("testValidPublishToUsers", testValidPublishToUsers),
+        ("testPublishToUsersRequiresAtLeastOneUser", testPublishToUsersRequiresAtLeastOneUser),
+        ("testPublishToUsersUserShouldNotBeAnEmptyString", testPublishToUsersUserShouldNotBeAnEmptyString),
+        ("testPublishToUsersUsernameShouldBeLessThan165Characters", testPublishToUsersUsernameShouldBeLessThan165Characters),
+        ("testPublishToMoreThan1000UsersShouldFail", testPublishToMoreThan1000UsersShouldFail),
+        ("testItShouldAuthenticateTheUserSuccessfully", testItShouldAuthenticateTheUserSuccessfully),
+        ("testItShouldFailToAuthenticateUserWithEmptyId", testItShouldFailToAuthenticateUserWithEmptyId),
+        ("testItShouldFailToAuthenticateUserWithIdThatIsTooLong", testItShouldFailToAuthenticateUserWithIdThatIsTooLong),
+        ("testItShouldDeleteTheUserSuccessfully", testItShouldDeleteTheUserSuccessfully),
+        ("testItShouldFailToDeleteUserWithEmptyId", testItShouldFailToDeleteUserWithEmptyId),
+        ("testItShouldFailToDeleteUserWithIdThatIsTooLong", testItShouldFailToDeleteUserWithIdThatIsTooLong)
     ]
 }

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -18,7 +18,7 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertNoThrow(try pushNotifications.publish(interests, publishRequest) { (_) in })
+        XCTAssertNoThrow(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in })
     }
 
     func testInstanceIdShouldNotBeEmptyString() {
@@ -36,7 +36,7 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publish(interests, publishRequest) { (_) in }) { error in
+        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
             guard case PushNotificationsError.instanceIdCannotBeAnEmptyString = error else {
                 return XCTFail("It should return instanceIdCannotBeAnEmptyString error.")
             }
@@ -58,7 +58,7 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publish(interests, publishRequest) { (_) in }) { error in
+        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
             guard case PushNotificationsError.secretKeyCannotBeAnEmptyString = error else {
                 return XCTFail("It should return secretKeyCannotBeAnEmptyString error.")
             }
@@ -80,7 +80,7 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publish(interests, publishRequest) { (_) in }) { error in
+        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
             guard case PushNotificationsError.interestsArrayCannotBeEmpty = error else {
                 return XCTFail("It should return interestsArrayCannotBeEmpty error.")
             }
@@ -107,7 +107,7 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publish(interests, publishRequest) { (_) in }) { error in
+        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
             guard case PushNotificationsError.interestsArrayContainsTooManyInterests(let maximumNumberOfInterests) = error else {
                 return XCTFail("It should return interestsArrayContainsTooManyInterests error.")
             }
@@ -131,7 +131,7 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publish(interests, publishRequest) { (_) in }) { error in
+        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
             guard case PushNotificationsError.interestsArrayContainsAnInvalidInterest(let maximumInterestCharacterCount) = error else {
                 return XCTFail("It should return interestsArrayContainsAnInvalidInterest error.")
             }

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -347,7 +347,7 @@ final class PushNotificationsTests: XCTestCase {
     
         let exp = expectation(description: "It should successfully authenticate the user.")
 
-        pushNotifications.authenticateUser("aaa", completion: { result in
+        pushNotifications.generateToken("aaa", completion: { result in
             switch result {
             case .value(let jwtTokenString):
                 XCTAssertNotNil(jwtTokenString)
@@ -360,7 +360,7 @@ final class PushNotificationsTests: XCTestCase {
         waitForExpectations(timeout: 3)
     }
 
-    func testItShouldFailToAuthenticateUserWithEmptyId() {
+    func testItShouldFailToGenerateTokenWithEmptyId() {
         let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
         let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
@@ -368,7 +368,7 @@ final class PushNotificationsTests: XCTestCase {
     
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.authenticateUser("", completion: { result in
+        pushNotifications.generateToken("", completion: { result in
             switch result {
             case .value:
                 XCTFail()
@@ -381,7 +381,7 @@ final class PushNotificationsTests: XCTestCase {
         waitForExpectations(timeout: 3)
     }
 
-    func testItShouldFailToAuthenticateUserWithIdThatIsTooLong() {
+    func testItShouldFailToGenerateTokenWithIdThatIsTooLong() {
         let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
         let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
@@ -389,7 +389,7 @@ final class PushNotificationsTests: XCTestCase {
     
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.authenticateUser("askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniownvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoin", completion: { result in
+        pushNotifications.generateToken("askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniownvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoin", completion: { result in
             switch result {
             case .value:
                 XCTFail()
@@ -478,8 +478,8 @@ final class PushNotificationsTests: XCTestCase {
         ("testPublishToUsersUsernameShouldBeLessThan165Characters", testPublishToUsersUsernameShouldBeLessThan165Characters),
         ("testPublishToMoreThan1000UsersShouldFail", testPublishToMoreThan1000UsersShouldFail),
         ("testItShouldAuthenticateTheUserSuccessfully", testItShouldAuthenticateTheUserSuccessfully),
-        ("testItShouldFailToAuthenticateUserWithEmptyId", testItShouldFailToAuthenticateUserWithEmptyId),
-        ("testItShouldFailToAuthenticateUserWithIdThatIsTooLong", testItShouldFailToAuthenticateUserWithIdThatIsTooLong),
+        ("testItShouldFailToGenerateTokenWithEmptyId", testItShouldFailToGenerateTokenWithEmptyId),
+        ("testItShouldFailToGenerateTokenWithIdThatIsTooLong", testItShouldFailToGenerateTokenWithIdThatIsTooLong),
         ("testItShouldDeleteTheUserSuccessfully", testItShouldDeleteTheUserSuccessfully),
         ("testItShouldFailToDeleteUserWithEmptyId", testItShouldFailToDeleteUserWithEmptyId),
         ("testItShouldFailToDeleteUserWithIdThatIsTooLong", testItShouldFailToDeleteUserWithIdThatIsTooLong)

--- a/Tests/PushNotificationsTests/PushNotificationsTests.swift
+++ b/Tests/PushNotificationsTests/PushNotificationsTests.swift
@@ -4,8 +4,8 @@ import XCTest
 final class PushNotificationsTests: XCTestCase {
 
     func testValidInstance() {
-        let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
-        let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
 
@@ -18,12 +18,24 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertNoThrow(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in })
+        let exp = expectation(description: "It should successfully publish to the interests.")
+
+        pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+            switch result {
+            case .value(let publishId):
+                XCTAssertNotNil(publishId)
+                exp.fulfill()
+            case .error:
+                XCTFail()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
     }
 
     func testInstanceIdShouldNotBeEmptyString() {
         let instanceId = ""
-        let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
 
@@ -36,15 +48,23 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
-            guard case PushNotificationsError.instanceIdCannotBeAnEmptyString = error else {
-                return XCTFail("It should return instanceIdCannotBeAnEmptyString error.")
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
             }
-        }
+        })
+
+        waitForExpectations(timeout: 3)
     }
 
     func testSecretKeyShouldNotBeEmptyString() {
-        let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
         let secretKey = ""
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
@@ -58,16 +78,24 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
-            guard case PushNotificationsError.secretKeyCannotBeAnEmptyString = error else {
-                return XCTFail("It should return secretKeyCannotBeAnEmptyString error.")
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
             }
-        }
+        })
+
+        waitForExpectations(timeout: 3)
     }
 
     func testInterestsArrayShouldNotBeEmpty() {
-        let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
-        let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
 
@@ -80,16 +108,24 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
-            guard case PushNotificationsError.interestsArrayCannotBeEmpty = error else {
-                return XCTFail("It should return interestsArrayCannotBeEmpty error.")
+        let exp = expectation(description: "It should return an error.")
+
+        pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
             }
-        }
+        })
+
+        waitForExpectations(timeout: 3)
     }
 
     func testInterestsArrayShouldContainMaximumOf100Interests() {
-        let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
-        let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f56446"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
 
@@ -107,18 +143,24 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
-            guard case PushNotificationsError.interestsArrayContainsTooManyInterests(let maximumNumberOfInterests) = error else {
-                return XCTFail("It should return interestsArrayContainsTooManyInterests error.")
-            }
+        let exp = expectation(description: "It should return an error.")
 
-            XCTAssertEqual(maximumNumberOfInterests, 100, "Interests array can contain maximum of 100 interests.")
-        }
+        pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
     }
 
         func testInterestInTheArrayIsTooLong() {
-        let instanceId = "c7c52433-8c65-43e6-9ef2-922d9ed9e196"
-        let secretKey = "39817C9BCBF7F053CB151343D54EE75"
+        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
 
         let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
 
@@ -131,13 +173,19 @@ final class PushNotificationsTests: XCTestCase {
             ]
         ]
 
-        XCTAssertThrowsError(try pushNotifications.publishToInterests(interests, publishRequest) { (_) in }) { error in
-            guard case PushNotificationsError.interestsArrayContainsAnInvalidInterest(let maximumInterestCharacterCount) = error else {
-                return XCTFail("It should return interestsArrayContainsAnInvalidInterest error.")
-            }
+        let exp = expectation(description: "It should return an error.")
 
-            XCTAssertEqual(maximumInterestCharacterCount, 164, "Interest name can be constructed from maximum of 164 characters.")
-        }
+        pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
+            switch result {
+            case .value:
+                XCTFail()
+            case .error(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        })
+
+        waitForExpectations(timeout: 3)
     }
 
     static var allTests = [


### PR DESCRIPTION
### What?

Offer a secure method to directly target a notification to an authenticated user in your application.

### Why?

This can be useful if you want to send personalized notifications, for example, if you have an events application, you could send invites targeting specific users knowing that these notifications can’t be accessed by other users.