### PR TITLE
Adds new imports to make it work on Swift 5

### DIFF
--- a/Sources/PushNotifications/JWTTokenGenerable.swift
+++ b/Sources/PushNotifications/JWTTokenGenerable.swift
@@ -1,4 +1,8 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
 import SwiftJWT
 
 public struct JWTPayload {

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Error thrown by PushNotifications.
 public enum PushNotificationsError: Error {


### PR DESCRIPTION
Adds: 
```
#if canImport(FoundationNetworking)
import FoundationNetworking
#endif
```
to two files, in order to make it compile on Swift 5, when using Vapor