### PR TITLE
Use Swift 'Result' type

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ let publishRequest = [
 // Publish To Interests
 pushNotifications.publishToInterests(interests, publishRequest, completion: { result in
     switch result {
-    case .value(let publishId):
+    case .success(let publishId):
         print("\(publishId)")
-    case .error(let error):
+    case .failure(let error):
         print("\(error)")
     }
 })
@@ -73,9 +73,9 @@ pushNotifications.publishToInterests(interests, publishRequest, completion: { re
 // Publish To Users
 pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"], publishRequest, completion: { result in
     switch result {
-    case .value(let publishId):
+    case .success(let publishId):
         print("\(publishId)")
-    case .error(let error):
+    case .failure(let error):
         print("\(error)")
     }
 })
@@ -83,11 +83,11 @@ pushNotifications.publishToUsers(["jonathan", "jordan", "luís", "luka", "mina"]
 // Authenticate User
 pushNotifications.generateToken("Elmo", completion: { result in
     switch result {
-    case .value(let jwtToken):
+    case .success(let jwtToken):
         // 'jwtToken' is a Dictionary<String, String>
         // Example: ["token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWEiLCJleHAiOjE"]
         print("\(jwtToken)")
-    case .error(let error):
+    case .failure(let error):
         print("\(error)")
     }
 })
@@ -95,9 +95,9 @@ pushNotifications.generateToken("Elmo", completion: { result in
 // Delete User
 pushNotifications.deleteUser("Elmo", completion: { result in
     switch result {
-    case .value:
+    case .success:
         print("User deleted 👌")
-    case .error(let error):
+    case .failure(let error):
         print("\(error)")
     }
 })

--- a/Sources/PushNotifications/JWTTokenGenerable.swift
+++ b/Sources/PushNotifications/JWTTokenGenerable.swift
@@ -6,11 +6,11 @@ import FoundationNetworking
 import SwiftJWT
 
 protocol JWTTokenGenerable {
-    func jwtTokenString(payload: JWTPayload, completion: @escaping CompletionHandler<Result<String, Error>>)
+    func jwtTokenString(payload: JWTPayload, completion: @escaping (Result<String, Error>) -> Void)
 }
 
 extension JWTTokenGenerable {
-    func jwtTokenString(payload: JWTPayload, completion: @escaping CompletionHandler<Result<String, Error>>) {
+    func jwtTokenString(payload: JWTPayload, completion: @escaping (Result<String, Error>) -> Void) {
         let key = payload.key.data(using: .utf8)!
         let jwtEncoder = JWTEncoder(jwtSigner: JWTSigner.hs256(key: key))
         do {

--- a/Sources/PushNotifications/JWTTokenGenerable.swift
+++ b/Sources/PushNotifications/JWTTokenGenerable.swift
@@ -16,9 +16,9 @@ extension JWTTokenGenerable {
         do {
             let jwt = JWT(claims: JWTClaims(sub: payload.sub, exp: payload.exp, iss: payload.iss))
             let jwtTokenString = try jwtEncoder.encodeToString(jwt)
-            completion(.value(jwtTokenString))
+            completion(.success(jwtTokenString))
         } catch {
-            completion(.error(error))
+            completion(.failure(error))
         }
     }
 }

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -3,8 +3,6 @@ import Foundation
 import FoundationNetworking
 #endif
 
-public typealias CompletionHandler<T> = (_ result: T) -> Void
-
 /**
 PushNotifications struct implements publish method
 that is used to publish push notifications to specified interests.
@@ -147,7 +145,7 @@ public struct PushNotifications: JWTTokenGenerable {
     */
     public func publishToInterests(_ interests: [String],
                                    _ publishRequest: [String: Any],
-                                   completion: @escaping CompletionHandler<Result<String, Error>>) {
+                                   completion: @escaping (Result<String, Error>) -> Void) {
         if instanceId.isEmpty {
             return completion(.failure(PushNotificationsError.instanceIdCannotBeAnEmptyString))
         }
@@ -219,7 +217,7 @@ public struct PushNotifications: JWTTokenGenerable {
     */
     public func publishToUsers(_ users: [String],
                                _ publishRequest: [String: Any],
-                               completion: @escaping CompletionHandler<Result<String, Error>>) {
+                               completion: @escaping (Result<String, Error>) -> Void) {
         if users.count < 1 {
             let errorMessage = "[PushNotifications] - Must supply at least one user id."
             return completion(.failure(PushNotificationsError.error(errorMessage)))
@@ -278,7 +276,7 @@ public struct PushNotifications: JWTTokenGenerable {
     ````
     */
     public func generateToken(_ userId: String,
-                              completion: @escaping CompletionHandler<Result<[String: String], Error>>) {
+                              completion: @escaping (Result<[String: String], Error>) -> Void) {
         if userId.count < 1 {
             return completion(.failure(PushNotificationsError.error("User Id cannot be empty")))
         }
@@ -332,7 +330,7 @@ public struct PushNotifications: JWTTokenGenerable {
     ````
     */
     public func deleteUser(_ userId: String,
-                           completion: @escaping CompletionHandler<Result<Void, Error>>) {
+                           completion: @escaping (Result<Void, Error>) -> Void) {
         if userId.count < 1 {
             return completion(.failure(PushNotificationsError.error("[PushNotifications] - User Id cannot be empty.")))
         }

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -161,6 +161,7 @@ public struct PushNotifications: JWTTokenGenerable {
         }
 
         if interests.count > 100 {
+            // swiftlint:disable:next line_length
             return completion(.failure(PushNotificationsError.interestsArrayContainsTooManyInterests(maxInterests: 100)))
         }
 

--- a/Sources/PushNotifications/Services/NetworkService.swift
+++ b/Sources/PushNotifications/Services/NetworkService.swift
@@ -58,15 +58,15 @@ struct NetworkService {
 
             networkRequest(request: request) { result in
                 switch result {
-                case .value:
-                    completion(.value(()))
+                case .success:
+                    completion(.success(()))
 
-                case .error(let error):
-                    completion(.error(error))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
             }
         } catch {
-            completion(.error(error))
+            completion(.failure(error))
         }
     }
 
@@ -110,20 +110,20 @@ struct NetworkService {
 
             networkRequest(request: request) { result in
                 switch result {
-                case .value(let deviceData):
+                case .success(let deviceData):
                     do {
                         let publishResponse = try JSONDecoder().decode(PublishResponse.self, from: deviceData)
-                        completion(.value(publishResponse.id))
+                        completion(.success(publishResponse.id))
                     } catch {
-                        completion(.error(error))
+                        completion(.failure(error))
                     }
 
-                case .error(let error):
-                    completion(.error(error))
+                case .failure(let error):
+                    completion(.failure(error))
                 }
             }
         } catch {
-            completion(.error(error))
+            completion(.failure(error))
         }
     }
 
@@ -135,20 +135,20 @@ struct NetworkService {
         let dataTask = session.dataTask(with: request) { data, response, error in
             guard let data = data else {
                 let errorMessage = "[PushNotifications] - Publish request failed. `data` is nil."
-                return completion(.error(PushNotificationsError.error(errorMessage)))
+                return completion(.failure(PushNotificationsError.error(errorMessage)))
             }
             guard let httpURLResponse = response as? HTTPURLResponse else {
                 let errorMessage = "[PushNotifications] - Publish request failed. `httpURLResponse` is nil."
-                return completion(.error(PushNotificationsError.error(errorMessage)))
+                return completion(.failure(PushNotificationsError.error(errorMessage)))
             }
 
             let statusCode = httpURLResponse.statusCode
             guard statusCode >= 200 && statusCode < 300, error == nil else {
                 let errorMessage = "[PushNotifications] - Request failed. HTTP status code: \(statusCode)"
-                return completion(.error(PushNotificationsError.error(errorMessage)))
+                return completion(.failure(PushNotificationsError.error(errorMessage)))
             }
 
-            completion(.value(data))
+            completion(.success(data))
         }
 
         dataTask.resume()

--- a/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
+++ b/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
@@ -22,11 +22,11 @@ final class InstanceConfigurationTests: XCTestCase {
 
         pushNotifications.publishToInterests(interests, publishRequest) { result in
             switch result {
-            case .value(let publishId):
+            case .success(let publishId):
                 XCTAssertNotNil(publishId)
                 exp.fulfill()
 
-            case .error:
+            case .failure:
                 XCTFail("Result should not contain an error.")
             }
         }
@@ -53,10 +53,10 @@ final class InstanceConfigurationTests: XCTestCase {
 
         pushNotifications.publishToInterests(interests, publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -84,10 +84,10 @@ final class InstanceConfigurationTests: XCTestCase {
 
         pushNotifications.publishToInterests(interests, publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }

--- a/Tests/PushNotificationsTests/InterestsTests.swift
+++ b/Tests/PushNotificationsTests/InterestsTests.swift
@@ -22,10 +22,10 @@ final class InterestsTests: XCTestCase {
 
         pushNotifications.publishToInterests(interests, publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -58,10 +58,10 @@ final class InterestsTests: XCTestCase {
 
         pushNotifications.publishToInterests(interests, publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -93,10 +93,10 @@ final class InterestsTests: XCTestCase {
 
         pushNotifications.publishToInterests(interests, publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }

--- a/Tests/PushNotificationsTests/TokenTests.swift
+++ b/Tests/PushNotificationsTests/TokenTests.swift
@@ -13,13 +13,13 @@ final class TokenTests: XCTestCase {
 
         pushNotifications.generateToken("aaa") { result in
             switch result {
-            case .value(let jwtToken):
+            case .success(let jwtToken):
                 // 'jwtToken' is a Dictionary<String, String>
                 // Example: ["token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWEiLCJleHAiOjE"]
                 XCTAssertNotNil(jwtToken)
                 exp.fulfill()
 
-            case .error:
+            case .failure:
                 XCTFail("Result should not contain an error.")
             }
         }
@@ -37,10 +37,10 @@ final class TokenTests: XCTestCase {
 
         pushNotifications.generateToken("") { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -64,10 +64,10 @@ final class TokenTests: XCTestCase {
         niowenviwniwvnienoin
         """) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }

--- a/Tests/PushNotificationsTests/UsersTests.swift
+++ b/Tests/PushNotificationsTests/UsersTests.swift
@@ -26,11 +26,11 @@ final class UsersTests: XCTestCase {
                                           "mina"],
                                          publishRequest) { result in
             switch result {
-            case .value(let publishId):
+            case .success(let publishId):
                 XCTAssertNotNil(publishId)
                 exp.fulfill()
 
-            case .error:
+            case .failure:
                 XCTFail("Result should not contain an error.")
             }
         }
@@ -56,10 +56,10 @@ final class UsersTests: XCTestCase {
 
         pushNotifications.publishToUsers([], publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -86,10 +86,10 @@ final class UsersTests: XCTestCase {
 
         pushNotifications.publishToUsers([""], publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -121,10 +121,10 @@ final class UsersTests: XCTestCase {
         veiniowenviwniwvnienoin
         """], publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -157,10 +157,10 @@ final class UsersTests: XCTestCase {
 
         pushNotifications.publishToUsers(users, publishRequest) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -179,10 +179,10 @@ final class UsersTests: XCTestCase {
 
         pushNotifications.deleteUser("aaa") { result in
             switch result {
-            case .value:
+            case .success:
                 exp.fulfill()
 
-            case .error:
+            case .failure:
                 XCTFail("Result should not contain an error.")
             }
         }
@@ -200,10 +200,10 @@ final class UsersTests: XCTestCase {
 
         pushNotifications.deleteUser("") { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }
@@ -227,10 +227,10 @@ final class UsersTests: XCTestCase {
         wniveiniowenviwniwvnienoin
         """) { result in
             switch result {
-            case .value:
+            case .success:
                 XCTFail("Result should not contain a value.")
 
-            case .error(let error):
+            case .failure(let error):
                 XCTAssertNotNil(error)
                 exp.fulfill()
             }


### PR DESCRIPTION
This PR:

- Refactors the SDK to use the `Result` type included in the Swift standard library
  - Since this was introduced in Swift 5.0, the `swift-tools-version` in `Package.swift` is upgraded accordingly
  - Uses the new `Result` API in code example comments and README
  - Removes the `CompletionHandler` typealias for returning a `Result` in a closure