### PR TITLE
Error reporting improvements

### DIFF
--- a/Sources/PushNotifications/Models/PushNotificationsError.swift
+++ b/Sources/PushNotifications/Models/PushNotificationsError.swift
@@ -2,30 +2,30 @@ import Foundation
 
 /// Error thrown by PushNotifications.
 public enum PushNotificationsError: Error {
-    //// `instanceId` cannot be an empty String.
-    case instanceIdCannotBeAnEmptyString
-    //// `secretKey` cannot be an empty String.
-    case secretKeyCannotBeAnEmptyString
-    //// `interests` array cannot be empty.
-    case interestsArrayCannotBeEmpty
 
-    /**
-     General error.
-
-     - Parameter: error message.
-     */
+    /// A non-specific error.
+    /// - Parameter: The error message.
     case error(String)
 
-    /**
-    Interests array exceeded the number of maximum interests allowed.
+    /// The `instanceId` cannot be an empty String.
+    case instanceIdCannotBeAnEmptyString
 
-    - Parameter: maximum interests allowed value.
-    */
-    case interestsArrayContainsTooManyInterests(maxInterests: UInt)
-    /**
-    Interests array contains at least one or more invalid interests.
+    /// The `interests` array cannot be empty.
+    case interestsArrayCannotBeEmpty
 
-    - Parameter: maximum characters allowed value.
-    */
+    /// The `interests` array contains at least one or more invalid interests.
+    /// - maxCharacters: The maximum number of characters allowed.
     case interestsArrayContainsAnInvalidInterest(maxCharacters: UInt)
+
+    /// The `interests` array exceeded the number of maximum interests allowed.
+    /// - maxInterests: The maximum number of interests allowed.
+    case interestsArrayContainsTooManyInterests(maxInterests: UInt)
+
+    case internalError(_ error: Error)
+
+    /// The `secretKey` cannot be an empty String.
+    case secretKeyCannotBeAnEmptyString
+
+    /// The `userId` cannot be an empty String.
+    case userIdCannotBeAnEmptyString
 }

--- a/Sources/PushNotifications/Models/PushNotificationsError.swift
+++ b/Sources/PushNotifications/Models/PushNotificationsError.swift
@@ -1,11 +1,7 @@
 import Foundation
 
 /// Error thrown by PushNotifications.
-public enum PushNotificationsError: Error {
-
-    /// A non-specific error.
-    /// - Parameter: The error message.
-    case error(String)
+public enum PushNotificationsError: LocalizedError {
 
     /// The `instanceId` cannot be an empty String.
     case instanceIdCannotBeAnEmptyString
@@ -21,11 +17,102 @@ public enum PushNotificationsError: Error {
     /// - maxInterests: The maximum number of interests allowed.
     case interestsArrayContainsTooManyInterests(maxInterests: UInt)
 
+    /// An internal error occured.
+    ///
+    /// Some internal operation of the library has thrown an error. The reason for the failure
+    /// can be inspected via the `localizedDescription` property of the `error` parameter.
     case internalError(_ error: Error)
 
     /// The `secretKey` cannot be an empty String.
     case secretKeyCannotBeAnEmptyString
 
+    /// The `users` array cannot be empty.
+    case usersArrayCannotBeEmpty
+
+    /// The `users` array cannot contain any empty Strings.
+    case usersArrayCannotContainEmptyString
+
+    /// The `users` array contains at least one or more invalid users.
+    /// - maxCharacters: The maximum number of characters allowed.
+    case usersArrayContainsAnInvalidUser(maxCharacters: UInt)
+
+    /// The `users` array exceeded the number of maximum interests allowed.
+    /// - maxUsers: The maximum number of interests allowed.
+    case usersArrayContainsTooManyUsers(maxUsers: UInt)
+
     /// The `userId` cannot be an empty String.
     case userIdCannotBeAnEmptyString
+
+    /// The `userId` is invalid (i.e. it is too many characters).
+    /// - maxCharacters: The maximum number of characters allowed.
+    case userIdInvalid(maxCharacters: UInt)
+
+    public var errorDescription: String? {
+        switch self {
+        case .instanceIdCannotBeAnEmptyString:
+            return NSLocalizedString("The network response does not contain any data.",
+                                     comment: "'.instanceIdCannotBeAnEmptyString' error text")
+
+        case .interestsArrayCannotBeEmpty:
+            return NSLocalizedString("The 'interests' array cannot be empty.",
+                                     comment: "'.interestsArrayCannotBeEmpty' error text")
+
+        case .interestsArrayContainsAnInvalidInterest(maxCharacters: let maxCharacters):
+            return NSLocalizedString("The 'interests' array contains at least one interest longer than \(maxCharacters) characters.",
+                                     comment: "'.interestsArrayContainsAnInvalidInterest' error text")
+
+        case .interestsArrayContainsTooManyInterests(maxInterests: let maxInterests):
+            return NSLocalizedString("The 'interests' array cannot contain more than \(maxInterests) interests.",
+                                     comment: "'.interestsArrayContainsTooManyInterests' error text")
+
+        case .internalError(let error):
+            return NSLocalizedString("The request failed with error: \(error)",
+                                     comment: "'.internalError' error text")
+
+        case .secretKeyCannotBeAnEmptyString:
+            return NSLocalizedString("The 'secretKey' cannot be an empty string.",
+                                     comment: "'.secretKeyCannotBeAnEmptyString' error text")
+
+        case .usersArrayCannotBeEmpty:
+            return NSLocalizedString("The 'users' array cannot be empty.",
+                                     comment: "'.usersArrayCannotBeEmpty' error text")
+
+        case .usersArrayCannotContainEmptyString:
+            return NSLocalizedString("The 'users' array cannot contain any user IDs that are empty strings.",
+                                     comment: "'.usersArrayCannotContainEmptyString' error text")
+
+        case .usersArrayContainsAnInvalidUser(maxCharacters: let maxCharacters):
+            return NSLocalizedString("The 'users' array contains at least one user ID longer than \(maxCharacters) characters.",
+                                     comment: "'.usersArrayContainsAnInvalidUser' error text")
+
+        case .usersArrayContainsTooManyUsers(maxUsers: let maxUsers):
+            return NSLocalizedString("The 'users' array cannot contain more than \(maxUsers) user IDs.",
+                                     comment: "'.usersArrayContainsTooManyUsers' error text")
+
+        case .userIdCannotBeAnEmptyString:
+            return NSLocalizedString("The 'userId' cannot be an empty string.",
+                                     comment: "'.userIdCannotBeAnEmptyString' error text")
+
+        case .userIdInvalid(maxCharacters: let maxCharacters):
+            return NSLocalizedString("The 'userId' is longer than \(maxCharacters) characters.",
+                                     comment: "'.userIdInvalid' error text")
+        }
+    }
+}
+
+extension PushNotificationsError {
+
+    /// Creates a `PushNotificationsError` which wraps another `Error`, offering additional context if it can be determined.
+    /// - Parameter error: The `Error` to wrap inside the resulting `PushNotificationsError`.
+    init(from error: Error) {
+
+        // Handle the case where `error` is already a `PushNotificationsError`
+        if error is PushNotificationsError {
+            // swiftlint:disable:next force_cast
+            self = error as! PushNotificationsError
+            return
+        } else {
+            self = .internalError(error)
+        }
+    }
 }

--- a/Sources/PushNotifications/Models/PushNotificationsError.swift
+++ b/Sources/PushNotifications/Models/PushNotificationsError.swift
@@ -58,7 +58,9 @@ public enum PushNotificationsError: LocalizedError {
                                      comment: "'.interestsArrayCannotBeEmpty' error text")
 
         case .interestsArrayContainsAnInvalidInterest(maxCharacters: let maxCharacters):
-            return NSLocalizedString("The 'interests' array contains at least one interest longer than \(maxCharacters) characters.",
+            return NSLocalizedString("""
+            The 'interests' array contains at least one interest longer than \(maxCharacters) characters.
+            """,
                                      comment: "'.interestsArrayContainsAnInvalidInterest' error text")
 
         case .interestsArrayContainsTooManyInterests(maxInterests: let maxInterests):
@@ -82,7 +84,9 @@ public enum PushNotificationsError: LocalizedError {
                                      comment: "'.usersArrayCannotContainEmptyString' error text")
 
         case .usersArrayContainsAnInvalidUser(maxCharacters: let maxCharacters):
-            return NSLocalizedString("The 'users' array contains at least one user ID longer than \(maxCharacters) characters.",
+            return NSLocalizedString("""
+            The 'users' array contains at least one user ID longer than \(maxCharacters) characters.
+            """,
                                      comment: "'.usersArrayContainsAnInvalidUser' error text")
 
         case .usersArrayContainsTooManyUsers(maxUsers: let maxUsers):
@@ -102,7 +106,8 @@ public enum PushNotificationsError: LocalizedError {
 
 extension PushNotificationsError {
 
-    /// Creates a `PushNotificationsError` which wraps another `Error`, offering additional context if it can be determined.
+    /// Creates a `PushNotificationsError` which wraps another `Error`,
+    /// offering additional context if it can be determined.
     /// - Parameter error: The `Error` to wrap inside the resulting `PushNotificationsError`.
     init(from error: Error) {
 

--- a/Sources/PushNotifications/PushNotifications.swift
+++ b/Sources/PushNotifications/PushNotifications.swift
@@ -23,7 +23,7 @@ public struct PushNotifications: JWTTokenGenerable {
 
     private static let maxInterests: UInt = 100
     private static let maxInterestOrUserIdLength: UInt = 164
-    private static let maxNumUserIdsWhenPublishing = 1000
+    private static let maxNumUserIdsWhenPublishing: UInt = 1000
 
     /**
      Creates a new `PushNotifications` instance.
@@ -81,7 +81,7 @@ public struct PushNotifications: JWTTokenGenerable {
     */
     public func publishToInterests(_ interests: [String],
                                    _ publishRequest: [String: Any],
-                                   completion: @escaping (Result<String, Error>) -> Void) {
+                                   completion: @escaping (Result<String, PushNotificationsError>) -> Void) {
         if instanceId.isEmpty {
             return completion(.failure(PushNotificationsError.instanceIdCannotBeAnEmptyString))
         }
@@ -105,8 +105,9 @@ public struct PushNotifications: JWTTokenGenerable {
         }
 
         networkService.publishToInterests(interests,
-                                          publishRequest: publishRequest,
-                                          completion: completion)
+                                          publishRequest: publishRequest) { result in
+            completion(result.mapError({ PushNotificationsError(from: $0) }))
+        }
     }
 
     /**
@@ -153,12 +154,13 @@ public struct PushNotifications: JWTTokenGenerable {
     */
     public func publishToUsers(_ users: [String],
                                _ publishRequest: [String: Any],
-                               completion: @escaping (Result<String, Error>) -> Void) {
+                               completion: @escaping (Result<String, PushNotificationsError>) -> Void) {
         if users.isEmpty {
             return completion(.failure(PushNotificationsError.usersArrayCannotBeEmpty))
         }
 
         if users.count > Self.maxNumUserIdsWhenPublishing {
+            // swiftlint:disable:next line_length
             return completion(.failure(PushNotificationsError.usersArrayContainsTooManyUsers(maxUsers: Self.maxNumUserIdsWhenPublishing)))
         }
 
@@ -168,12 +170,14 @@ public struct PushNotifications: JWTTokenGenerable {
         }
 
         if users.contains(where: { $0.count > Self.maxInterestOrUserIdLength }) {
+            // swiftlint:disable:next line_length
             return completion(.failure(PushNotificationsError.usersArrayContainsAnInvalidUser(maxCharacters: Self.maxInterestOrUserIdLength)))
         }
 
         networkService.publishToUsers(users,
-                                      publishRequest: publishRequest,
-                                      completion: completion)
+                                      publishRequest: publishRequest) { result in
+            completion(result.mapError({ PushNotificationsError(from: $0) }))
+        }
     }
 
     /**
@@ -202,12 +206,13 @@ public struct PushNotifications: JWTTokenGenerable {
     ````
     */
     public func generateToken(_ userId: String,
-                              completion: @escaping (Result<[String: String], Error>) -> Void) {
+                              completion: @escaping (Result<[String: String], PushNotificationsError>) -> Void) {
         if userId.isEmpty {
             return completion(.failure(PushNotificationsError.userIdCannotBeAnEmptyString))
         }
 
         if userId.count > Self.maxInterestOrUserIdLength {
+            // swiftlint:disable:next line_length
             return completion(.failure(PushNotificationsError.userIdInvalid(maxCharacters: Self.maxInterestOrUserIdLength)))
         }
 
@@ -220,7 +225,7 @@ public struct PushNotifications: JWTTokenGenerable {
                 completion(.success(["token": jwtTokenString]))
 
             case .failure(let error):
-                completion(.failure(error))
+                completion(.failure(PushNotificationsError(from: error)))
             }
         }
     }
@@ -251,15 +256,18 @@ public struct PushNotifications: JWTTokenGenerable {
     ````
     */
     public func deleteUser(_ userId: String,
-                           completion: @escaping (Result<Void, Error>) -> Void) {
+                           completion: @escaping (Result<Void, PushNotificationsError>) -> Void) {
         if userId.isEmpty {
             return completion(.failure(PushNotificationsError.userIdCannotBeAnEmptyString))
         }
 
         if userId.count > Self.maxInterestOrUserIdLength {
+            // swiftlint:disable:next line_length
             return completion(.failure(PushNotificationsError.userIdInvalid(maxCharacters: Self.maxInterestOrUserIdLength)))
         }
 
-        networkService.deleteUser(userId, completion: completion)
+        networkService.deleteUser(userId) { result in
+            completion(result.mapError({ PushNotificationsError(from: $0) }))
+        }
     }
 }


### PR DESCRIPTION
This PR:

- Uses typed error cases instead of instances of `PushNotifications.error("some error message")`
  - Adds new error definitions where needed
- Localizes `PushNotificationsError`
- Types the error in the returned `Result` of public API methods as `PusherNotificationsError`