### PR TITLE
Testing improvements

### DIFF
--- a/Sources/PushNotifications/Models/PushNotificationsError.swift
+++ b/Sources/PushNotifications/Models/PushNotificationsError.swift
@@ -124,6 +124,7 @@ extension PushNotificationsError {
 
 extension PushNotificationsError: Equatable {
 
+    // swiftlint:disable:next cyclomatic_complexity
     public static func == (lhs: PushNotificationsError, rhs: PushNotificationsError) -> Bool {
         switch (lhs, rhs) {
         case (.instanceIdCannotBeAnEmptyString, .instanceIdCannotBeAnEmptyString):
@@ -132,10 +133,12 @@ extension PushNotificationsError: Equatable {
         case (.interestsArrayCannotBeEmpty, .interestsArrayCannotBeEmpty):
             return true
 
-        case (.interestsArrayContainsAnInvalidInterest(let maxOne), .interestsArrayContainsAnInvalidInterest(let maxTwo)):
+        case (.interestsArrayContainsAnInvalidInterest(let maxOne),
+              .interestsArrayContainsAnInvalidInterest(let maxTwo)):
             return maxOne == maxTwo
 
-        case (.interestsArrayContainsTooManyInterests(let maxOne), .interestsArrayContainsTooManyInterests(let maxTwo)):
+        case (.interestsArrayContainsTooManyInterests(let maxOne),
+              .interestsArrayContainsTooManyInterests(let maxTwo)):
             return maxOne == maxTwo
 
         case (.internalError(let errorOne), .internalError(let errorTwo)):

--- a/Sources/PushNotifications/Models/PushNotificationsError.swift
+++ b/Sources/PushNotifications/Models/PushNotificationsError.swift
@@ -121,3 +121,49 @@ extension PushNotificationsError {
         }
     }
 }
+
+extension PushNotificationsError: Equatable {
+
+    public static func == (lhs: PushNotificationsError, rhs: PushNotificationsError) -> Bool {
+        switch (lhs, rhs) {
+        case (.instanceIdCannotBeAnEmptyString, .instanceIdCannotBeAnEmptyString):
+            return true
+
+        case (.interestsArrayCannotBeEmpty, .interestsArrayCannotBeEmpty):
+            return true
+
+        case (.interestsArrayContainsAnInvalidInterest(let maxOne), .interestsArrayContainsAnInvalidInterest(let maxTwo)):
+            return maxOne == maxTwo
+
+        case (.interestsArrayContainsTooManyInterests(let maxOne), .interestsArrayContainsTooManyInterests(let maxTwo)):
+            return maxOne == maxTwo
+
+        case (.internalError(let errorOne), .internalError(let errorTwo)):
+            return errorOne.localizedDescription == errorTwo.localizedDescription
+
+        case (.secretKeyCannotBeAnEmptyString, .secretKeyCannotBeAnEmptyString):
+            return true
+
+        case (.usersArrayCannotBeEmpty, .usersArrayCannotBeEmpty):
+            return true
+
+        case (.usersArrayCannotContainEmptyString, .usersArrayCannotContainEmptyString):
+            return true
+
+        case (.usersArrayContainsAnInvalidUser(let maxOne), .usersArrayContainsAnInvalidUser(let maxTwo)):
+            return maxOne == maxTwo
+
+        case (.usersArrayContainsTooManyUsers(let maxOne), .usersArrayContainsTooManyUsers(let maxTwo)):
+            return maxOne == maxTwo
+
+        case (.userIdCannotBeAnEmptyString, .userIdCannotBeAnEmptyString):
+            return true
+
+        case (.userIdInvalid(let maxOne), .userIdInvalid(let maxTwo)):
+            return maxOne == maxTwo
+
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/PushNotificationsTests/Extensions/XCTest+Pusher.swift
+++ b/Tests/PushNotificationsTests/Extensions/XCTest+Pusher.swift
@@ -1,0 +1,68 @@
+@testable import PushNotifications
+import XCTest
+
+extension XCTestCase {
+
+    /// Verify that a result of an API request contains a specific error.
+    ///
+    /// This helper method is useful when testing against expected error conditions.
+    /// - Parameters:
+    ///   - result: A `Result<T, PushNotificationsError>` returned from an API request.
+    ///   - expectation: An `XCTestExpectation` which will be fulfilled after inspecting `result`.
+    ///   - expectedError: The `PusherError` which is expected to be found inside `result`.
+    ///   - file: The source file that called the receiver.
+    ///   - function: The function that called the receiver.
+    ///   - line: The line number of the call site of the receiver.
+    func verifyAPIResultFailure<T>(_ result: Result<T, PushNotificationsError>,
+                                   expectation: XCTestExpectation,
+                                   expectedError: PushNotificationsError,
+                                   file: StaticString = #file,
+                                   function: StaticString = #function,
+                                   line: UInt = #line) {
+        switch result {
+        case .success:
+            XCTFail("This test should not succeed.", file: file, line: line)
+
+        case .failure(let error):
+            XCTAssertEqual(error, expectedError, file: file, line: line)
+        }
+        expectation.fulfill()
+    }
+
+    /// Verify that a result of an API request contains a successful result.
+    /// - Parameters:
+    ///   - result: A `Result<T, PushNotificationsError>` returned from an API request.
+    ///   - expectation: An `XCTestExpectation` which will be fulfilled after inspecting `result`.
+    ///   - validateResultCallback: A closure executed when `result` contains a decoded value.
+    ///                             This can be used to inspect the value and determine its correctness.
+    ///   - file: The source file that called the receiver.
+    ///   - function: The function that called the receiver.
+    ///   - line: The line number of the call site of the receiver.
+    func verifyAPIResultSuccess<T>(_ result: Result<T, PushNotificationsError>,
+                                   expectation: XCTestExpectation,
+                                   validateResultCallback: (T) -> Void,
+                                   file: StaticString = #file,
+                                   function: StaticString = #function,
+                                   line: UInt = #line) {
+        switch result {
+        case .success(let value):
+            validateResultCallback(value)
+
+        case .failure(let error):
+            XCTFail("This test should not fail. Failed with error: \(error.localizedDescription)",
+                    file: file,
+                    line: line)
+        }
+        expectation.fulfill()
+    }
+}
+
+extension XCTestExpectation {
+
+    /// Creates a `XCTestExpectation` with a `description` based on the name of calling function.
+    /// - Parameter function: The function that called the receiver.
+    convenience init(function: StaticString = #function) {
+        let function = String(describing: function).components(separatedBy: "()").first!
+        self.init(description: "\(function)Expectation")
+    }
+}

--- a/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
+++ b/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class InstanceConfigurationTests: XCTestCase {
 
     func testValidInstance() {
-        let exp = expectation(description: "It should successfully publish to the interests.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.validArray,
                                                      TestObjects.Publish.publishRequest) { result in
@@ -13,11 +13,11 @@ final class InstanceConfigurationTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testInstanceIdShouldNotBeEmptyString() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.emptyInstanceId.publishToInterests(TestObjects.Interests.validArray,
                                                               TestObjects.Publish.publishRequest) { result in
@@ -26,11 +26,11 @@ final class InstanceConfigurationTests: XCTestCase {
                                         expectedError: .instanceIdCannotBeAnEmptyString)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testSecretKeyShouldNotBeEmptyString() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.emptySecretKey.publishToInterests(TestObjects.Interests.validArray,
                                                              TestObjects.Publish.publishRequest) { result in
@@ -39,6 +39,6 @@ final class InstanceConfigurationTests: XCTestCase {
                                         expectedError: .secretKeyCannotBeAnEmptyString)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 }

--- a/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
+++ b/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
@@ -8,13 +8,8 @@ final class InstanceConfigurationTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.validArray,
                                                      TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success(let publishId):
+            self.verifyAPIResultSuccess(result, expectation: exp) { publishId in
                 XCTAssertNotNil(publishId)
-                exp.fulfill()
-
-            case .failure:
-                XCTFail("Result should not contain an error.")
             }
         }
 
@@ -26,14 +21,9 @@ final class InstanceConfigurationTests: XCTestCase {
 
         TestObjects.Client.emptyInstanceId.publishToInterests(TestObjects.Interests.validArray,
                                                               TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .instanceIdCannotBeAnEmptyString)
         }
 
         waitForExpectations(timeout: 3)
@@ -44,14 +34,9 @@ final class InstanceConfigurationTests: XCTestCase {
 
         TestObjects.Client.emptySecretKey.publishToInterests(TestObjects.Interests.validArray,
                                                              TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .secretKeyCannotBeAnEmptyString)
         }
 
         waitForExpectations(timeout: 3)

--- a/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
+++ b/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
@@ -4,23 +4,10 @@ import XCTest
 final class InstanceConfigurationTests: XCTestCase {
 
     func testValidInstance() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let interests = ["pizza", "vegan-pizza"]
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should successfully publish to the interests.")
 
-        pushNotifications.publishToInterests(interests, publishRequest) { result in
+        TestObjects.Client.shared.publishToInterests(TestObjects.Interests.validArray,
+                                                     TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success(let publishId):
                 XCTAssertNotNil(publishId)
@@ -35,23 +22,10 @@ final class InstanceConfigurationTests: XCTestCase {
     }
 
     func testInstanceIdShouldNotBeEmptyString() {
-        let instanceId = ""
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let interests = ["pizza", "vegan-pizza"]
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToInterests(interests, publishRequest) { result in
+        TestObjects.Client.emptyInstanceId.publishToInterests(TestObjects.Interests.validArray,
+                                                              TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -66,23 +40,10 @@ final class InstanceConfigurationTests: XCTestCase {
     }
 
     func testSecretKeyShouldNotBeEmptyString() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = ""
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let interests = ["pizza", "vegan-pizza"]
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToInterests(interests, publishRequest) { result in
+        TestObjects.Client.emptySecretKey.publishToInterests(TestObjects.Interests.validArray,
+                                                             TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")

--- a/Tests/PushNotificationsTests/InterestsTests.swift
+++ b/Tests/PushNotificationsTests/InterestsTests.swift
@@ -6,7 +6,7 @@ final class InterestsTests: XCTestCase {
     // N.B: Testing the success case is covered in InstanceConfigurationTests.testValidInstance()
 
     func testInterestsArrayShouldNotBeEmpty() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.emptyArray,
                                                      TestObjects.Publish.publishRequest) { result in
@@ -15,11 +15,11 @@ final class InterestsTests: XCTestCase {
                                         expectedError: .interestsArrayCannotBeEmpty)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testInterestsArrayShouldNotContainAnEmptyString() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToInterests([TestObjects.Interests.emptyString],
                                                      TestObjects.Publish.publishRequest) { result in
@@ -29,11 +29,11 @@ final class InterestsTests: XCTestCase {
                                         expectedError: error)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testInterestsArrayShouldContainMaximumOf100Interests() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooMany,
                                                      TestObjects.Publish.publishRequest) { result in
@@ -42,11 +42,11 @@ final class InterestsTests: XCTestCase {
                                         expectedError: .interestsArrayContainsTooManyInterests(maxInterests: 100))
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testInterestInTheArrayIsTooLong() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooLong,
                                                      TestObjects.Publish.publishRequest) { result in
@@ -55,6 +55,6 @@ final class InterestsTests: XCTestCase {
                                         expectedError: .interestsArrayContainsAnInvalidInterest(maxCharacters: 164))
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 }

--- a/Tests/PushNotificationsTests/InterestsTests.swift
+++ b/Tests/PushNotificationsTests/InterestsTests.swift
@@ -10,14 +10,9 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.emptyArray,
                                                      TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .interestsArrayCannotBeEmpty)
         }
 
         waitForExpectations(timeout: 3)
@@ -28,14 +23,10 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests([TestObjects.Interests.emptyString],
                                                      TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            let error = PushNotificationsError.internalError(NetworkService.Error.failedResponse(statusCode: 422))
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: error)
         }
 
         waitForExpectations(timeout: 3)
@@ -46,14 +37,9 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooMany,
                                                      TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .interestsArrayContainsTooManyInterests(maxInterests: 100))
         }
 
         waitForExpectations(timeout: 3)
@@ -64,14 +50,9 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooLong,
                                                      TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .interestsArrayContainsAnInvalidInterest(maxCharacters: 164))
         }
 
         waitForExpectations(timeout: 3)

--- a/Tests/PushNotificationsTests/InterestsTests.swift
+++ b/Tests/PushNotificationsTests/InterestsTests.swift
@@ -3,24 +3,31 @@ import XCTest
 
 final class InterestsTests: XCTestCase {
 
+    // N.B: Testing the success case is covered in InstanceConfigurationTests.testValidInstance()
+
     func testInterestsArrayShouldNotBeEmpty() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let interests: [String] = []
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToInterests(interests, publishRequest) { result in
+        TestObjects.Client.shared.publishToInterests(TestObjects.Interests.emptyArray,
+                                                     TestObjects.Publish.publishRequest) { result in
+            switch result {
+            case .success:
+                XCTFail("Result should not contain a value.")
+
+            case .failure(let error):
+                XCTAssertNotNil(error)
+                exp.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 3)
+    }
+
+    func testInterestsArrayShouldNotContainAnEmptyString() {
+        let exp = expectation(description: "It should return an error.")
+
+        TestObjects.Client.shared.publishToInterests([TestObjects.Interests.emptyString],
+                                                     TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -35,28 +42,10 @@ final class InterestsTests: XCTestCase {
     }
 
     func testInterestsArrayShouldContainMaximumOf100Interests() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f56446"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        var interests: [String] = []
-
-        for _ in 0...100 {
-            interests.append("Interest")
-        }
-
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToInterests(interests, publishRequest) { result in
+        TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooMany,
+                                                     TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -71,27 +60,10 @@ final class InterestsTests: XCTestCase {
     }
 
     func testInterestInTheArrayIsTooLong() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let interests = ["""
-        kjfioiowejfiofjeijifjwiejifwejiojfiowejifwjiofejifwejiejfiojioewjiofjiowefeewfinii\
-        enwvinvinwkjfioiowejfiofjeijifjwiejifwejiojfiowejifwjiofejifwejiejfiojioewjiofjiow\
-        efeewfiniienwvinvinw
-        """]
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToInterests(interests, publishRequest) { result in
+        TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooLong,
+                                                     TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")

--- a/Tests/PushNotificationsTests/Models/TestObjects.swift
+++ b/Tests/PushNotificationsTests/Models/TestObjects.swift
@@ -1,0 +1,67 @@
+import Foundation
+@testable import PushNotifications
+
+struct TestObjects {
+
+    struct Client {
+
+        private static let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
+        private static let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
+
+        static let shared = PushNotifications(instanceId: instanceId, secretKey: secretKey)
+        static let emptyInstanceId = PushNotifications(instanceId: "", secretKey: secretKey)
+        static let emptySecretKey = PushNotifications(instanceId: instanceId, secretKey: "")
+    }
+
+    struct Interests {
+
+        static let emptyArray = [String]()
+
+        static let emptyString = ""
+
+        static let tooLong = ["""
+        kjfioiowejfiofjeijifjwiejifwejiojfiowejifwjiofejifwejiejfiojioewjiofjiowefeewfinii\
+        enwvinvinwkjfioiowejfiofjeijifjwiejifwejiojfiowejifwjiofejifwejiejfiojioewjiofjiow\
+        efeewfiniienwvinvinw
+        """]
+
+        static let tooMany = [String](repeating: "Interest", count: 101)
+
+        static let validArray = ["pizza",
+                                 "vegan-pizza"]
+    }
+
+    struct Publish {
+        static let publishRequest = [
+            "apns": [
+                "aps": [
+                    "alert": "hi"
+                ]
+            ]
+        ]
+    }
+
+    struct UserIDs {
+
+        static let emptyArray = [String]()
+
+        static let emptyString = ""
+
+        static let tooLong = """
+        askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniow\
+        nvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinv\
+        ioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwnivei\
+        niowenviwniwvnienoin
+        """
+
+        static let tooMany = [String](repeating: validId, count: 1000)
+
+        static let validArray = ["jonathan",
+                                 "jordan",
+                                 "luís",
+                                 "luka",
+                                 "mina"]
+
+        static let validId = "aaa"
+    }
+}

--- a/Tests/PushNotificationsTests/TokenTests.swift
+++ b/Tests/PushNotificationsTests/TokenTests.swift
@@ -4,14 +4,9 @@ import XCTest
 final class TokenTests: XCTestCase {
 
     func testItShouldAuthenticateTheUserSuccessfully() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
         let exp = expectation(description: "It should successfully authenticate the user.")
 
-        pushNotifications.generateToken("aaa") { result in
+        TestObjects.Client.shared.generateToken(TestObjects.UserIDs.validId) { result in
             switch result {
             case .success(let jwtToken):
                 // 'jwtToken' is a Dictionary<String, String>
@@ -28,14 +23,9 @@ final class TokenTests: XCTestCase {
     }
 
     func testItShouldFailToGenerateTokenWithEmptyId() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.generateToken("") { result in
+        TestObjects.Client.shared.generateToken(TestObjects.UserIDs.emptyString) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -50,19 +40,9 @@ final class TokenTests: XCTestCase {
     }
 
     func testItShouldFailToGenerateTokenWithIdThatIsTooLong() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.generateToken("""
-        askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveniow\
-        nvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinv\
-        ioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwnivei\
-        niowenviwniwvnienoin
-        """) { result in
+        TestObjects.Client.shared.generateToken(TestObjects.UserIDs.tooLong) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")

--- a/Tests/PushNotificationsTests/TokenTests.swift
+++ b/Tests/PushNotificationsTests/TokenTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class TokenTests: XCTestCase {
 
     func testItShouldAuthenticateTheUserSuccessfully() {
-        let exp = expectation(description: "It should successfully authenticate the user.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.validId) { result in
             self.verifyAPIResultSuccess(result, expectation: exp) { jwt in
@@ -12,11 +12,11 @@ final class TokenTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testItShouldFailToGenerateTokenWithEmptyId() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.emptyString) { result in
             self.verifyAPIResultFailure(result,
@@ -24,11 +24,11 @@ final class TokenTests: XCTestCase {
                                         expectedError: .userIdCannotBeAnEmptyString)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testItShouldFailToGenerateTokenWithIdThatIsTooLong() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.tooLong) { result in
             self.verifyAPIResultFailure(result,
@@ -36,6 +36,6 @@ final class TokenTests: XCTestCase {
                                         expectedError: .userIdInvalid(maxCharacters: 164))
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 }

--- a/Tests/PushNotificationsTests/TokenTests.swift
+++ b/Tests/PushNotificationsTests/TokenTests.swift
@@ -7,15 +7,8 @@ final class TokenTests: XCTestCase {
         let exp = expectation(description: "It should successfully authenticate the user.")
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.validId) { result in
-            switch result {
-            case .success(let jwtToken):
-                // 'jwtToken' is a Dictionary<String, String>
-                // Example: ["token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhYWEiLCJleHAiOjE"]
-                XCTAssertNotNil(jwtToken)
-                exp.fulfill()
-
-            case .failure:
-                XCTFail("Result should not contain an error.")
+            self.verifyAPIResultSuccess(result, expectation: exp) { jwt in
+                XCTAssertNotNil(jwt)
             }
         }
 
@@ -26,14 +19,9 @@ final class TokenTests: XCTestCase {
         let exp = expectation(description: "It should return an error.")
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.emptyString) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .userIdCannotBeAnEmptyString)
         }
 
         waitForExpectations(timeout: 3)
@@ -43,14 +31,9 @@ final class TokenTests: XCTestCase {
         let exp = expectation(description: "It should return an error.")
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.tooLong) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .userIdInvalid(maxCharacters: 164))
         }
 
         waitForExpectations(timeout: 3)

--- a/Tests/PushNotificationsTests/UsersTests.swift
+++ b/Tests/PushNotificationsTests/UsersTests.swift
@@ -4,27 +4,10 @@ import XCTest
 final class UsersTests: XCTestCase {
 
     func testValidPublishToUsers() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should successfully publish to users.")
 
-        pushNotifications.publishToUsers(["jonathan",
-                                          "jordan",
-                                          "luís",
-                                          "luka",
-                                          "mina"],
-                                         publishRequest) { result in
+        TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.validArray,
+                                                 TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success(let publishId):
                 XCTAssertNotNil(publishId)
@@ -39,22 +22,10 @@ final class UsersTests: XCTestCase {
     }
 
     func testPublishToUsersRequiresAtLeastOneUser() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToUsers([], publishRequest) { result in
+        TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.emptyArray,
+                                                 TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -69,22 +40,10 @@ final class UsersTests: XCTestCase {
     }
 
     func testPublishToUsersUserShouldNotBeAnEmptyString() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToUsers([""], publishRequest) { result in
+        TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.emptyString],
+                                                 TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -99,27 +58,10 @@ final class UsersTests: XCTestCase {
     }
 
     func testPublishToUsersUsernameShouldBeLessThan165Characters() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToUsers(["""
-        askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneivenio\
-        wnvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwi\
-        nvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioiwni\
-        veiniowenviwniwvnienoin
-        """], publishRequest) { result in
+        TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.tooLong],
+                                                 TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -134,28 +76,10 @@ final class UsersTests: XCTestCase {
     }
 
     func testPublishToMoreThan1000UsersShouldFail() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
-        let publishRequest = [
-            "apns": [
-                "aps": [
-                    "alert": "hi"
-                ]
-            ]
-        ]
-
-        var users: [String] = []
-
-        for _ in 0...1000 {
-            users.append("a")
-        }
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.publishToUsers(users, publishRequest) { result in
+        TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.tooMany,
+                                                 TestObjects.Publish.publishRequest) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -170,14 +94,9 @@ final class UsersTests: XCTestCase {
     }
 
     func testItShouldDeleteTheUserSuccessfully() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
         let exp = expectation(description: "It should successfully delete the user.")
 
-        pushNotifications.deleteUser("aaa") { result in
+        TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.validId) { result in
             switch result {
             case .success:
                 exp.fulfill()
@@ -191,14 +110,9 @@ final class UsersTests: XCTestCase {
     }
 
     func testItShouldFailToDeleteUserWithEmptyId() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.deleteUser("") { result in
+        TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.emptyString) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")
@@ -213,19 +127,9 @@ final class UsersTests: XCTestCase {
     }
 
     func testItShouldFailToDeleteUserWithIdThatIsTooLong() {
-        let instanceId = "1b880590-6301-4bb5-b34f-45db1c5f5644"
-        let secretKey = "F8AC0B756E50DF235F642D6F0DC2CDE0328CD9184B3874C5E91AB2189BB722FE"
-
-        let pushNotifications = PushNotifications(instanceId: instanceId, secretKey: secretKey)
-
         let exp = expectation(description: "It should return an error.")
 
-        pushNotifications.deleteUser("""
-        askdsakdjlksajkldjkajdksjkdjkjkjdkajksjkljkajkdsjkajkdjkoiwqjijiofiowenfioneiveni\
-        ownvionioeniovnioenwinvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioen\
-        winvioenioniwenvioiwniveiniowenviwniwvnienoiwnvionioeniovnioenwinvioenioniwenvioi\
-        wniveiniowenviwniwvnienoin
-        """) { result in
+        TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.tooLong) { result in
             switch result {
             case .success:
                 XCTFail("Result should not contain a value.")

--- a/Tests/PushNotificationsTests/UsersTests.swift
+++ b/Tests/PushNotificationsTests/UsersTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class UsersTests: XCTestCase {
 
     func testValidPublishToUsers() {
-        let exp = expectation(description: "It should successfully publish to users.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.validArray,
                                                  TestObjects.Publish.publishRequest) { result in
@@ -13,11 +13,11 @@ final class UsersTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testPublishToUsersRequiresAtLeastOneUser() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.emptyArray,
                                                  TestObjects.Publish.publishRequest) { result in
@@ -26,11 +26,11 @@ final class UsersTests: XCTestCase {
                                         expectedError: .usersArrayCannotBeEmpty)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testPublishToUsersUserShouldNotBeAnEmptyString() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.emptyString],
                                                  TestObjects.Publish.publishRequest) { result in
@@ -39,11 +39,11 @@ final class UsersTests: XCTestCase {
                                         expectedError: .usersArrayCannotContainEmptyString)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testPublishToUsersUsernameShouldBeLessThan165Characters() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.tooLong],
                                                  TestObjects.Publish.publishRequest) { result in
@@ -52,11 +52,11 @@ final class UsersTests: XCTestCase {
                                         expectedError: .usersArrayContainsAnInvalidUser(maxCharacters: 164))
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testPublishToMoreThan1000UsersShouldFail() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.tooMany,
                                                  TestObjects.Publish.publishRequest) { result in
@@ -66,11 +66,11 @@ final class UsersTests: XCTestCase {
                                         expectedError: error)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testItShouldDeleteTheUserSuccessfully() {
-        let exp = expectation(description: "It should successfully delete the user.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.validId) { result in
             self.verifyAPIResultSuccess(result, expectation: exp) { voidValue in
@@ -78,11 +78,11 @@ final class UsersTests: XCTestCase {
             }
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testItShouldFailToDeleteUserWithEmptyId() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.emptyString) { result in
             self.verifyAPIResultFailure(result,
@@ -90,11 +90,11 @@ final class UsersTests: XCTestCase {
                                         expectedError: .userIdCannotBeAnEmptyString)
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 
     func testItShouldFailToDeleteUserWithIdThatIsTooLong() {
-        let exp = expectation(description: "It should return an error.")
+        let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.tooLong) { result in
             self.verifyAPIResultFailure(result,
@@ -102,6 +102,6 @@ final class UsersTests: XCTestCase {
                                         expectedError: .userIdInvalid(maxCharacters: 164))
         }
 
-        waitForExpectations(timeout: 3)
+        wait(for: [exp], timeout: 3)
     }
 }

--- a/Tests/PushNotificationsTests/UsersTests.swift
+++ b/Tests/PushNotificationsTests/UsersTests.swift
@@ -8,13 +8,8 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.validArray,
                                                  TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success(let publishId):
+            self.verifyAPIResultSuccess(result, expectation: exp) { publishId in
                 XCTAssertNotNil(publishId)
-                exp.fulfill()
-
-            case .failure:
-                XCTFail("Result should not contain an error.")
             }
         }
 
@@ -26,14 +21,9 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.emptyArray,
                                                  TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .usersArrayCannotBeEmpty)
         }
 
         waitForExpectations(timeout: 3)
@@ -44,14 +34,9 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.emptyString],
                                                  TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .usersArrayCannotContainEmptyString)
         }
 
         waitForExpectations(timeout: 3)
@@ -62,14 +47,9 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.tooLong],
                                                  TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .usersArrayContainsAnInvalidUser(maxCharacters: 164))
         }
 
         waitForExpectations(timeout: 3)
@@ -80,14 +60,10 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.tooMany,
                                                  TestObjects.Publish.publishRequest) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            let error = PushNotificationsError.internalError(NetworkService.Error.failedResponse(statusCode: 422))
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: error)
         }
 
         waitForExpectations(timeout: 3)
@@ -97,12 +73,8 @@ final class UsersTests: XCTestCase {
         let exp = expectation(description: "It should successfully delete the user.")
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.validId) { result in
-            switch result {
-            case .success:
-                exp.fulfill()
-
-            case .failure:
-                XCTFail("Result should not contain an error.")
+            self.verifyAPIResultSuccess(result, expectation: exp) { voidValue in
+                XCTAssertNotNil(voidValue)
             }
         }
 
@@ -113,14 +85,9 @@ final class UsersTests: XCTestCase {
         let exp = expectation(description: "It should return an error.")
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.emptyString) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .userIdCannotBeAnEmptyString)
         }
 
         waitForExpectations(timeout: 3)
@@ -130,14 +97,9 @@ final class UsersTests: XCTestCase {
         let exp = expectation(description: "It should return an error.")
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.tooLong) { result in
-            switch result {
-            case .success:
-                XCTFail("Result should not contain a value.")
-
-            case .failure(let error):
-                XCTAssertNotNil(error)
-                exp.fulfill()
-            }
+            self.verifyAPIResultFailure(result,
+                                        expectation: exp,
+                                        expectedError: .userIdInvalid(maxCharacters: 164))
         }
 
         waitForExpectations(timeout: 3)

--- a/Tests/PushNotificationsTests/XCTestManifests.swift
+++ b/Tests/PushNotificationsTests/XCTestManifests.swift
@@ -20,6 +20,7 @@ extension InterestsTests {
         ("testInterestInTheArrayIsTooLong", testInterestInTheArrayIsTooLong),
         ("testInterestsArrayShouldContainMaximumOf100Interests", testInterestsArrayShouldContainMaximumOf100Interests),
         ("testInterestsArrayShouldNotBeEmpty", testInterestsArrayShouldNotBeEmpty),
+        ("testInterestsArrayShouldNotContainAnEmptyString", testInterestsArrayShouldNotContainAnEmptyString),
     ]
 }
 


### PR DESCRIPTION
This PR makes the Tests more maintainable and concise:

- Removes repeated test objects to their own `TestObjects.swift` source file
- Adds `Result` verification helper methods
  - Also conforms `PushNotificationsError` to `Equatable` so that specific errors can be tested for
- Also adds a missing `testInterestsArrayShouldNotContainAnEmptyString()` test case