### PR TITLE
Test `Result` verification improvements

### DIFF
--- a/Tests/PushNotificationsTests/Extensions/XCTest+Pusher.swift
+++ b/Tests/PushNotificationsTests/Extensions/XCTest+Pusher.swift
@@ -3,25 +3,28 @@ import XCTest
 
 extension XCTestCase {
 
-    /// Verify that a result of an API request contains a specific error.
+    /// Verifies that a `Result` contains a specific error.
     ///
     /// This helper method is useful when testing against expected error conditions.
     /// - Parameters:
-    ///   - result: A `Result<T, PushNotificationsError>` returned from an API request.
-    ///   - expectation: An `XCTestExpectation` which will be fulfilled after inspecting `result`.
-    ///   - expectedError: The `PusherError` which is expected to be found inside `result`.
+    ///   - result: A `Result<Success, Failure>` returned from an API request (or similar operation).
+    ///             Where `Failure: Error & Equatable`.
     ///   - file: The source file that called the receiver.
     ///   - function: The function that called the receiver.
     ///   - line: The line number of the call site of the receiver.
-    func verifyAPIResultFailure<T>(_ result: Result<T, PushNotificationsError>,
-                                   expectation: XCTestExpectation,
-                                   expectedError: PushNotificationsError,
-                                   file: StaticString = #file,
-                                   function: StaticString = #function,
-                                   line: UInt = #line) {
+    ///   - expectation: An `XCTestExpectation` which will be fulfilled after inspecting `result`.
+    ///   - expectedError: The `Failure` which is expected to be found inside `result`.
+    func verifyResultFailure<Success, Failure>(_ result: Result<Success, Failure>,
+                                               file: StaticString = #file,
+                                               function: StaticString = #function,
+                                               line: UInt = #line,
+                                               expectation: XCTestExpectation,
+                                               expectedError: Failure) where Failure: Error & Equatable {
         switch result {
-        case .success:
-            XCTFail("This test should not succeed.", file: file, line: line)
+        case .success(let value):
+            XCTFail("This test should not succeed. Instead found value: \(String(describing: value))",
+                    file: file,
+                    line: line)
 
         case .failure(let error):
             XCTAssertEqual(error, expectedError, file: file, line: line)
@@ -29,27 +32,28 @@ extension XCTestCase {
         expectation.fulfill()
     }
 
-    /// Verify that a result of an API request contains a successful result.
+    /// Verifies that a `Result` contains a successful value.
     /// - Parameters:
-    ///   - result: A `Result<T, PushNotificationsError>` returned from an API request.
-    ///   - expectation: An `XCTestExpectation` which will be fulfilled after inspecting `result`.
-    ///   - validateResultCallback: A closure executed when `result` contains a decoded value.
-    ///                             This can be used to inspect the value and determine its correctness.
+    ///   - result: A `Result<Success, Failure>` returned from an API request (or similar operation).
+    ///             Where `Failure: Error`.
     ///   - file: The source file that called the receiver.
     ///   - function: The function that called the receiver.
     ///   - line: The line number of the call site of the receiver.
-    func verifyAPIResultSuccess<T>(_ result: Result<T, PushNotificationsError>,
-                                   expectation: XCTestExpectation,
-                                   validateResultCallback: (T) -> Void,
-                                   file: StaticString = #file,
-                                   function: StaticString = #function,
-                                   line: UInt = #line) {
+    ///   - expectation: An `XCTestExpectation` which will be fulfilled after inspecting `result`.
+    ///   - validateResultCallback: A closure executed when `result` contains a decoded value.
+    ///                             This can be used to inspect the value and determine its correctness.
+    func verifyResultSuccess<Success, Failure>(_ result: Result<Success, Failure>,
+                                               file: StaticString = #file,
+                                               function: StaticString = #function,
+                                               line: UInt = #line,
+                                               expectation: XCTestExpectation,
+                                               validateResultCallback: (Success) -> Void) where Failure: Error {
         switch result {
         case .success(let value):
             validateResultCallback(value)
 
         case .failure(let error):
-            XCTFail("This test should not fail. Failed with error: \(error.localizedDescription)",
+            XCTFail("This test should not fail. Instead found error: \(error.localizedDescription)",
                     file: file,
                     line: line)
         }

--- a/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
+++ b/Tests/PushNotificationsTests/InstanceConfigurationTests.swift
@@ -8,7 +8,7 @@ final class InstanceConfigurationTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.validArray,
                                                      TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultSuccess(result, expectation: exp) { publishId in
+            self.verifyResultSuccess(result, expectation: exp) { publishId in
                 XCTAssertNotNil(publishId)
             }
         }
@@ -21,9 +21,9 @@ final class InstanceConfigurationTests: XCTestCase {
 
         TestObjects.Client.emptyInstanceId.publishToInterests(TestObjects.Interests.validArray,
                                                               TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .instanceIdCannotBeAnEmptyString)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .instanceIdCannotBeAnEmptyString)
         }
 
         wait(for: [exp], timeout: 3)
@@ -34,9 +34,9 @@ final class InstanceConfigurationTests: XCTestCase {
 
         TestObjects.Client.emptySecretKey.publishToInterests(TestObjects.Interests.validArray,
                                                              TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .secretKeyCannotBeAnEmptyString)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .secretKeyCannotBeAnEmptyString)
         }
 
         wait(for: [exp], timeout: 3)

--- a/Tests/PushNotificationsTests/InterestsTests.swift
+++ b/Tests/PushNotificationsTests/InterestsTests.swift
@@ -10,9 +10,9 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.emptyArray,
                                                      TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .interestsArrayCannotBeEmpty)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .interestsArrayCannotBeEmpty)
         }
 
         wait(for: [exp], timeout: 3)
@@ -24,9 +24,9 @@ final class InterestsTests: XCTestCase {
         TestObjects.Client.shared.publishToInterests([TestObjects.Interests.emptyString],
                                                      TestObjects.Publish.publishRequest) { result in
             let error = PushNotificationsError.internalError(NetworkService.Error.failedResponse(statusCode: 422))
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: error)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: error)
         }
 
         wait(for: [exp], timeout: 3)
@@ -37,9 +37,9 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooMany,
                                                      TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .interestsArrayContainsTooManyInterests(maxInterests: 100))
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .interestsArrayContainsTooManyInterests(maxInterests: 100))
         }
 
         wait(for: [exp], timeout: 3)
@@ -50,9 +50,9 @@ final class InterestsTests: XCTestCase {
 
         TestObjects.Client.shared.publishToInterests(TestObjects.Interests.tooLong,
                                                      TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .interestsArrayContainsAnInvalidInterest(maxCharacters: 164))
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .interestsArrayContainsAnInvalidInterest(maxCharacters: 164))
         }
 
         wait(for: [exp], timeout: 3)

--- a/Tests/PushNotificationsTests/TokenTests.swift
+++ b/Tests/PushNotificationsTests/TokenTests.swift
@@ -7,7 +7,7 @@ final class TokenTests: XCTestCase {
         let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.validId) { result in
-            self.verifyAPIResultSuccess(result, expectation: exp) { jwt in
+            self.verifyResultSuccess(result, expectation: exp) { jwt in
                 XCTAssertNotNil(jwt)
             }
         }
@@ -19,9 +19,9 @@ final class TokenTests: XCTestCase {
         let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.emptyString) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .userIdCannotBeAnEmptyString)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .userIdCannotBeAnEmptyString)
         }
 
         wait(for: [exp], timeout: 3)
@@ -31,9 +31,9 @@ final class TokenTests: XCTestCase {
         let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.generateToken(TestObjects.UserIDs.tooLong) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .userIdInvalid(maxCharacters: 164))
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .userIdInvalid(maxCharacters: 164))
         }
 
         wait(for: [exp], timeout: 3)

--- a/Tests/PushNotificationsTests/UsersTests.swift
+++ b/Tests/PushNotificationsTests/UsersTests.swift
@@ -8,7 +8,7 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.validArray,
                                                  TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultSuccess(result, expectation: exp) { publishId in
+            self.verifyResultSuccess(result, expectation: exp) { publishId in
                 XCTAssertNotNil(publishId)
             }
         }
@@ -21,9 +21,9 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.emptyArray,
                                                  TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .usersArrayCannotBeEmpty)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .usersArrayCannotBeEmpty)
         }
 
         wait(for: [exp], timeout: 3)
@@ -34,9 +34,9 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.emptyString],
                                                  TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .usersArrayCannotContainEmptyString)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .usersArrayCannotContainEmptyString)
         }
 
         wait(for: [exp], timeout: 3)
@@ -47,9 +47,9 @@ final class UsersTests: XCTestCase {
 
         TestObjects.Client.shared.publishToUsers([TestObjects.UserIDs.tooLong],
                                                  TestObjects.Publish.publishRequest) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .usersArrayContainsAnInvalidUser(maxCharacters: 164))
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .usersArrayContainsAnInvalidUser(maxCharacters: 164))
         }
 
         wait(for: [exp], timeout: 3)
@@ -61,9 +61,9 @@ final class UsersTests: XCTestCase {
         TestObjects.Client.shared.publishToUsers(TestObjects.UserIDs.tooMany,
                                                  TestObjects.Publish.publishRequest) { result in
             let error = PushNotificationsError.internalError(NetworkService.Error.failedResponse(statusCode: 422))
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: error)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: error)
         }
 
         wait(for: [exp], timeout: 3)
@@ -73,7 +73,7 @@ final class UsersTests: XCTestCase {
         let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.validId) { result in
-            self.verifyAPIResultSuccess(result, expectation: exp) { voidValue in
+            self.verifyResultSuccess(result, expectation: exp) { voidValue in
                 XCTAssertNotNil(voidValue)
             }
         }
@@ -85,9 +85,9 @@ final class UsersTests: XCTestCase {
         let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.emptyString) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .userIdCannotBeAnEmptyString)
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .userIdCannotBeAnEmptyString)
         }
 
         wait(for: [exp], timeout: 3)
@@ -97,9 +97,9 @@ final class UsersTests: XCTestCase {
         let exp = XCTestExpectation(function: #function)
 
         TestObjects.Client.shared.deleteUser(TestObjects.UserIDs.tooLong) { result in
-            self.verifyAPIResultFailure(result,
-                                        expectation: exp,
-                                        expectedError: .userIdInvalid(maxCharacters: 164))
+            self.verifyResultFailure(result,
+                                     expectation: exp,
+                                     expectedError: .userIdInvalid(maxCharacters: 164))
         }
 
         wait(for: [exp], timeout: 3)


### PR DESCRIPTION
This PR:

- Renames the extension methods from `verifyAPIResultSuccess` -> `verifyResultSuccess` and `verifyAPIResultFailure` -> `verifyResultFailure`
- Changes `result` parameter of verification methods to `Result<Success, Failure>` (instead of expecting a specific `Error` type)
- Unexpected success / failure reporting improvements
- Reorders method arguments to ensure trailing closure compatibility with Swift 5.2 and earlier