### PR TITLE
NetworkService improvements

### DIFF
--- a/Sources/PushNotifications/Services/NetworkService.swift
+++ b/Sources/PushNotifications/Services/NetworkService.swift
@@ -4,7 +4,7 @@ struct NetworkService {
 
     enum Error: LocalizedError {
 
-        case emptyRepsonseData
+        case emptyResponseData
 
         case failedResponse(statusCode: Int)
 
@@ -14,7 +14,7 @@ struct NetworkService {
 
         var errorDescription: String? {
             switch self {
-            case .emptyRepsonseData:
+            case .emptyResponseData:
                 return NSLocalizedString("The network response does not contain any data.",
                                          comment: "'.emptyRepsonseData' error text")
 
@@ -161,7 +161,7 @@ struct NetworkService {
 
         let dataTask = session.dataTask(with: request) { data, response, error in
             guard let data = data else {
-                return completion(.failure(Error.emptyRepsonseData))
+                return completion(.failure(Error.emptyResponseData))
             }
             guard let httpURLResponse = response as? HTTPURLResponse else {
                 return completion(.failure(Error.unexpectedResponse))

--- a/Sources/PushNotifications/Services/NetworkService.swift
+++ b/Sources/PushNotifications/Services/NetworkService.swift
@@ -168,7 +168,7 @@ struct NetworkService {
             }
 
             let statusCode = httpURLResponse.statusCode
-            guard statusCode >= 200 && statusCode < 300, error == nil else {
+            guard 200...299 ~= statusCode, error == nil else {
                 return completion(.failure(Error.failedResponse(statusCode: statusCode)))
             }
 

--- a/Sources/PushNotifications/Services/NetworkService.swift
+++ b/Sources/PushNotifications/Services/NetworkService.swift
@@ -27,6 +27,7 @@ struct NetworkService {
             case .invalidOrEmptyUrlString:
                 return NSLocalizedString("The request URL string contains illegal characters or is an empty string.",
                                          comment: "'.invalidOrEmptyUrlString' error text")
+
             case .invalidPublishRequest:
                 return NSLocalizedString("The provided publish request data cannot be represented as JSON.",
                                          comment: "'.invalidPublishRequest' error text")
@@ -96,7 +97,7 @@ struct NetworkService {
         switch urlRequestResult {
         case .success(let request):
             networkRequest(request: request) { responseResult in
-                completion(responseResult.flatMap { responseData in
+                completion(responseResult.flatMap { _ in
                     Result.success(())
                 })
             }


### PR DESCRIPTION
This PR:

- Corrects a typo in the `emptyResponseData` error case
- Adds `invalidPublishRequest` error case, based on the best practice of adding a call to `JSONSerialization.isValidJSONObject(…)` before `JSONSerialization.data(withJSONObject:)`
- Uses the pattern match operator (i.e. `~=`) to check for a successful HTTP status code in response